### PR TITLE
Add CONTRIBUTING.md and SECURITY.md files to the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to Trace Viewer VS Code extension
+
+Thanks for your interest in the [Trace Viewer VS Code extension][vscode-ext]!. The following is a set of
+guidelines for contributing to the Trace Viewer extension for `VS Code` compatible tools. Information
+about the trace viewer capabilities can also be found in the [Trace Viewer Theia extension][trace-viewer]
+repository and its [issue tracers][theia-issues].
+
+## How to Contribute
+
+⚠️ **Important note** Setting up the development environment on Linux is the easiest. If you are trying
+to run the project on Windows or MacOs and you are encountering issues, please [contact us][contact-us].
+Follow the installation instruction in the [README](README.md).
+
+In order to contribute, please first [open an issue][issues] that clearly describes the bug you
+intend to fix or the feature you would like to add. Make sure you provide a way to reproduce the bug
+or test the proposed feature.
+
+Once you have your code ready for review, please  [open a pull request][pull-requests]. Please follow
+the [pull request guidelines][pr-guide]. A committer of the Trace Extension will then review your
+contribution and help to get it merged.
+
+## Code of Conduct
+
+This project is governed by the [Eclipse Community Code of Conduct][code-of-conduct].
+By participating, you are expected to uphold this code.
+
+## Eclipse Development Process
+
+This Eclipse Foundation open project is governed by the [Eclipse Foundation
+Development Process][dev-process] and operates under the terms of the [Eclipse IP Policy][ip-policy].
+
+## Eclipse Contributor Agreement
+
+In order to be able to contribute to Eclipse Foundation projects you must
+electronically sign the [Eclipse Contributor Agreement (ECA)][eca].
+
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
+
+For more information, please see the [Eclipse Committer Handbook][commiter-handbook].
+
+## Pull request guidelines
+
+**Changes to the project** are made by submitting code with a pull request (PR).
+
+* [How to write and submit changes][creating-changes]
+* [Example pull request][issue-56]
+
+**Good commit messages** make it easier to review code and understand why the changes were made.
+Please include a:
+
+* *Title:* Concise and complete title written in imperative (e.g. "Update Gitpod demo screenshots"
+or "Single-click to select or open trace")
+* *Problem:* What is the situation that needs to be resolved? Why does the problem need fixing?
+Link to related issues (e.g. "Fixes [#55][issue-55]").
+* *Solution:* What changes were made to resolve the situation? Why are these changes the right fix?
+* *Impact:* What impact do these changes have? (e.g. Numbers to show a performance improvement,
+screenshots or a video for a UI change)
+* [*Sign-off:*][sign-off] Use your full name and a long-term email address. This certifies that you
+have written the code and that, from a licensing perspective, the >
+* [How to format the message][commit-message-message]
+* [Example commit message][commit-message-example]
+
+## Contact
+
+For issues related to this extension, please open a GitHub tracker for the [VS Code Trace Extension][vscode-ext] repository.
+
+For issues concerning `eclipse-cdt-cloud`, please refer to the contact options listed on the [CDT Cloud website][cdt-cloud-website].
+
+[cdt-cloud-website]: https://cdt-cloud.io/contact/
+[code-of-conduct]: https://github.com/eclipse/.github/blob/master/CODE_OF_CONDUCT.md
+[commit-message-example]: https://github.com/theia-ide/theia-trace-extension/commit/bc18fcd110d7b8433293692421f2e4fb49f89bd6
+[commit-message-message]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[commiter-handbook]: https://www.eclipse.org/projects/handbook/#resources-commit
+[contact-us]: #contact
+[creating-changes]: https://www.dataschool.io/how-to-contribute-on-github/
+[dev-process]: https://eclipse.org/projects/dev_process
+[eca]: http://www.eclipse.org/legal/ECA.php
+[ip-policy]: https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
+[issues]: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/issues
+[issue-55]: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pull/55
+[issue-56]: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pull/56
+[pr-guide]: #pull-request-guidelines
+[pull-requests]: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pulls
+[sign-off]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff
+[theia-issues]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/issues
+[trace-viewer]: https://github.com/eclipse-cdt-cloud/theia-trace-extension
+[vscode-ext]: https://github.com/eclipse-cdt-cloud/vscode-trace-extension

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project started from the [vscode webview react project][vscode-webview-react]. It works this way, with the extension itself being in the `vscode-trace-extension` directory and the react application being in the `vscode-trace-webapps` directory.
 
+**👋 Want to help?** Read our [contributor guide](CONTRIBUTING.md) and follow the instructions to contribute code.
+
 ## Installation instructions
 
 The code was migrated from the [PR in theia-trace-extension][init-contrib].

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Vulnerability Reporting Policy
+
+If you think or suspect that you have discovered a new security vulnerability in this project, please __do not__ disclose it on GitHub, e.g. in an issue, a PR, or a discussion. Any such disclosure will be removed/deleted on sight, to promote orderly disclosure, as per the [Eclipse Foundation Vulnerability Reporting Policy][policy].
+
+Instead, please report any potential vulnerability to the Eclipse Foundation [Security Team][security]. Make sure to provide a concise description of the issue, a CWE, and other supporting information.
+
+[policy]: https://www.eclipse.org/security/policy.php
+[security]: https://www.eclipse.org/security


### PR DESCRIPTION
After the move to Eclipse CDT cloud project and it's GitHub organization add CONTRIBUTING.md and SECURITY.md.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>