### PR TITLE
Fix refresh of views when switching trace tabs

### DIFF
--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -56,7 +56,7 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
               break;
           case 'traceViewerTabActivated':
               if (message.data) {
-                  const experiment = convertSignalExperiment(JSONBig.parse(message.data.wrapper));
+                  const experiment = convertSignalExperiment(JSONBig.parse(message.data));
                   signalManager().fireTraceViewerTabActivatedSignal(experiment);
               }
               break;


### PR DESCRIPTION
The wrong object was being passed to the parser.

Fixes #63.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>