### PR TITLE
Support of changing the theme

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -108,6 +108,11 @@ export class TraceViewerPanel {
 	        }
 	    });
 
+	    vscode.window.onDidChangeActiveColorTheme(e => {
+	    	const wrapper = e.kind === 1 ? 'light' : 'dark';
+	    	this._panel.webview.postMessage({ command: 'set-theme', data: wrapper });
+	    });
+
 	    // Handle messages from the webview
 	    this._panel.webview.onDidReceiveMessage(message => {
 	        switch (message.command) {
@@ -126,6 +131,7 @@ export class TraceViewerPanel {
 	            if (this._experiment) {
 	                const wrapper: string = JSONBig.stringify(this._experiment);
 	                this._panel.webview.postMessage({command: 'set-experiment', data: wrapper});
+	                this.loadTheme();
 	            }
 	            return;
 	        }
@@ -173,6 +179,11 @@ export class TraceViewerPanel {
 
 	showOverview(): void {
 	    this._panel.webview.postMessage({command: 'open-overview'});
+	}
+
+	loadTheme(): void {
+		const wrapper = vscode.window.activeColorTheme.kind == 1 ? 'light' : 'dark';
+		this._panel.webview.postMessage({ command: 'set-theme', data: wrapper });
 	}
 
 	private _getHtmlForWebview() {

--- a/vscode-trace-webviews/src/style/trace-viewer.css
+++ b/vscode-trace-webviews/src/style/trace-viewer.css
@@ -6,7 +6,7 @@
     --theia-layout-color4: #383838;
     --theia-list-hoverBackground: var(--vscode-list-hoverBackground);
     --theia-selection-background: var(--vscode-list-activeSelectionBackground);
-    --theia-ui-font-color2: #f0f8ff;
+    --theia-ui-font-color2: var(--vscode-editor-foreground);
     --theia-ui-button-color: var(--vscode-button-background);
     --theia-accent-color3: var(--vscode-button-background);
     --theia-menu-background: var(--vscode-menu-background);

--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -26,6 +26,7 @@ interface VscodeAppState {
   tspClient: TspClient | undefined;
   outputs: OutputDescriptor[];
   overviewOutputDescriptor: OutputDescriptor| undefined;
+  theme: string;
 }
 
 class App extends React.Component<{}, VscodeAppState>  {
@@ -45,7 +46,8 @@ class App extends React.Component<{}, VscodeAppState>  {
           experiment: undefined,
           tspClient: undefined,
           outputs: [],
-          overviewOutputDescriptor: undefined
+          overviewOutputDescriptor: undefined,
+          theme: 'light'
       };
       this._signalHandler = new VsCodeMessageManager();
 
@@ -67,6 +69,9 @@ class App extends React.Component<{}, VscodeAppState>  {
               break;
           case 'open-overview':
               this.doHandleExperimentSetSignal(this.state.experiment);
+              break;
+          case 'set-theme':
+              this.doHandleThemeChanged(message.data);
           }
       });
       this.onOutputRemoved = this.onOutputRemoved.bind(this);
@@ -106,6 +111,12 @@ class App extends React.Component<{}, VscodeAppState>  {
       }
   }
 
+  protected doHandleThemeChanged(theme: string): void {
+      this.setState({ theme }, () => {
+          signalManager().fireThemeChangedSignal(theme);
+      });
+  }
+
   protected async getDefaultTraceOverviewOutputDescriptor(experiment: Experiment| undefined): Promise<OutputDescriptor | undefined> {
       const availableDescriptors = await this.getAvailableTraceOverviewOutputDescriptor(experiment);
       return availableDescriptors?.find(output => output.id === this.DEFAULT_OVERVIEW_DATA_PROVIDER_ID);
@@ -139,7 +150,7 @@ class App extends React.Component<{}, VscodeAppState>  {
                   // eslint-disable-next-line @typescript-eslint/no-empty-function
                   addResizeHandler={() => {}}
                   removeResizeHandler={() => {}}
-                  backgroundTheme={'dark'}></TraceContextComponent>
+                  backgroundTheme={this.state.theme}></TraceContextComponent>
               }
           </div>
       );


### PR DESCRIPTION
The background color of some elements of the extension, like the charts, was not being changed when a new theme was selected for VSCode.

Now, the extension recognizes if the theme is light or dark and changes the background of the charts accordingly.

https://user-images.githubusercontent.com/88502808/217006304-6c9f9c31-8bcd-444b-919a-6f79e7d89b78.mp4

Fixes #8.

Signed-off-by: Rodrigo Pinto <rodrigo.pinto@calian.ca>