### PR TITLE
Support Resizing of Charts

### DIFF
--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -40,6 +40,17 @@ class App extends React.Component<{}, VscodeAppState>  {
 
   private _onOverviewSelected = (payload: {traceId: string, outputDescriptor: OutputDescriptor}): void => this.doHandleOverviewSelectedSignal(payload);
 
+  protected resizeHandlers: (() => void)[] = [];
+  protected readonly addResizeHandler = (h: () => void): void => {
+      this.resizeHandlers.push(h);
+  };
+  protected readonly removeResizeHandler = (h: () => void): void => {
+      const index = this.resizeHandlers.indexOf(h, 0);
+      if (index > -1) {
+          this.resizeHandlers.splice(index, 1);
+      }
+  };
+
   constructor(props: {}) {
       super(props);
       this.state = {
@@ -74,6 +85,7 @@ class App extends React.Component<{}, VscodeAppState>  {
               this.doHandleThemeChanged(message.data);
           }
       });
+      window.addEventListener('resize', this.onResize);
       this.onOutputRemoved = this.onOutputRemoved.bind(this);
       this.onOverviewRemoved = this.onOverviewRemoved.bind(this);
       signalManager().on(Signals.OVERVIEW_OUTPUT_SELECTED, this._onOverviewSelected);
@@ -85,6 +97,11 @@ class App extends React.Component<{}, VscodeAppState>  {
 
   componentWillUnmount(): void {
       signalManager().off(Signals.OVERVIEW_OUTPUT_SELECTED, this._onOverviewSelected);
+      window.removeEventListener('resize', this.onResize);
+  }
+
+  private onResize = (): void => {
+    this.resizeHandlers.forEach(h => h());
   }
 
   private onOutputRemoved(outputId: string) {
@@ -148,8 +165,8 @@ class App extends React.Component<{}, VscodeAppState>  {
                   onOutputRemove={this.onOutputRemoved}
                   onOverviewRemove={this.onOverviewRemoved}
                   // eslint-disable-next-line @typescript-eslint/no-empty-function
-                  addResizeHandler={() => {}}
-                  removeResizeHandler={() => {}}
+                  addResizeHandler={this.addResizeHandler}
+                  removeResizeHandler={this.removeResizeHandler}
                   backgroundTheme={this.state.theme}></TraceContextComponent>
               }
           </div>


### PR DESCRIPTION
Adds window resize handlers to the trace-explorer-views-widget.tsx. These are implemented the same way as in theia-trace-extension trace-viewer.tsx widget.

Fixes: #9

Signed-off-by: Will Yang <william.yang@ericsson.com>