### PR TITLE
Fix Overview view selection menu style

### DIFF
--- a/vscode-trace-webviews/src/style/trace-viewer.css
+++ b/vscode-trace-webviews/src/style/trace-viewer.css
@@ -22,4 +22,17 @@
     --theia-input-background: var(--vscode-input-background);
     --theia-input-placeholder-foreground: var(--vscode-input-placeholderForeground);
     --theia-ui-font-family: var(--vscode-editor-fontFamily);
+    --theia-statusBar-background: var(--vscode-statusBar-background);
+    --theia-statusBar-foreground: var(--vscode-statusBar-foreground);
+    --theia-ui-font-size1: var(--vscode-font-size);
+    --theia-editorWidget-background: var(--vscode-editorWidget-background);
+    --theia-ui-padding: 6px;
+    --trace-extension-list-line-height: 16px;
+    --theia-secondaryButton-foreground: var(--vscode-input-background);
+    --theia-layout-color4: var(--vscode-editorWidget-background);
+    --theia-foreground: var(--vscode-editorWidget-foreground);
+    --vscode-editor-foreground: var(--vscode-foreground);
+    --theia-secondaryButton-foreground: var(--vscode-button-secondaryForeground);
+    --theia-secondaryButton-background: var(--vscode-button-secondaryBackground);
+    --theia-sideBar-foreground: var(--vscode-sideBarTitle-foreground);
 }


### PR DESCRIPTION
Added missing css mappings to fix overview view selection menu style:
![Screen Shot 2023-02-15 at 11 14 43 PM](https://user-images.githubusercontent.com/92893187/219274731-96797c34-a30a-4850-a036-9d4d0808205a.png)

Codicons are not integrated in webviews by default, due to which the close ('x') button on the top-right is missing. The following issue talks about how to let the webview load VS Code's bundled codicons: https://github.com/microsoft/vscode/issues/95199. I was unable to get this working properly though, for me the icons were showing up as an empty box, but the button was working:

[Screen Recording 2023-02-14 at 12.21.49 PM.webm](https://user-images.githubusercontent.com/92893187/219276229-639c8c86-50ff-459d-be95-e332942e71f8.webm)


I would suggest creating a separate issue to bundle codicons and get all webview codicon icons to show, or replace the  codicon icon with svg in `abstract-dialog-component.tsx`


fixes #76