### PR TITLE
Refresh "VIEWS" and "TRACES" after being minimized and re-opened

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -94,8 +94,8 @@ export class TraceViewerPanel {
 	    this._panel.onDidDispose(() => {
 	        this.dispose();
 	        TraceViewerPanel.activePanels[name] = undefined;
+	        signalManager().fireExperimentSelectedSignal(undefined);
 	        return this._disposables;
-
 	    });
 
 	    this._panel.onDidChangeViewState(e => {
@@ -104,6 +104,7 @@ export class TraceViewerPanel {
 	            setStatusFromPanel(name);
 	            if (this._experiment) {
 	                signalManager().fireTraceViewerTabActivatedSignal(this._experiment);
+	                signalManager().fireExperimentSelectedSignal(this._experiment);
 	            }
 	        }
 	    });

--- a/vscode-trace-webviews/src/trace-explorer/available-views/vscode-trace-explorer-views-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/available-views/vscode-trace-explorer-views-widget.tsx
@@ -44,9 +44,11 @@ class TraceExplorerViewsWidget extends React.Component<{}, AvailableViewsAppStat
               this.setState({ tspClientProvider: new TspClientProvider(message.data) });
               break;
           case 'experimentSelected':
+              let experiment: Experiment | undefined = undefined;
               if (message.data) {
-                  signalManager().fireExperimentSelectedSignal(convertSignalExperiment(JSONBig.parse(message.data)));
+                  experiment = convertSignalExperiment(JSONBig.parse(message.data));
               }
+              signalManager().fireExperimentSelectedSignal(experiment);
               break;
           }
       });


### PR DESCRIPTION
Make sure that selection of current experiments are persisted and restored in both views by sending and handling tabActivatedSignal and experimentSelectedSignal at relevant places.

Also, fix clearing of views and selection when trace panels are closed.

Fixes #64

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>