### PR TITLE
Fix showing of overview view with default when running in Theia

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -132,10 +132,11 @@ export class TraceViewerPanel {
 	            return;
 	        case 'webviewReady':
 	            // Post the tspTypescriptClient
-	            this._panel.webview.postMessage({command: 'set-tspClient', data: getTspClientUrl()});
 	            if (this._experiment) {
 	                const wrapper: string = JSONBig.stringify(this._experiment);
-	                this._panel.webview.postMessage({command: 'set-experiment', data: wrapper});
+	                this._panel.webview.postMessage({command: 'set-tspClient', data: getTspClientUrl(), experiment: wrapper});
+	            } else {
+	                this._panel.webview.postMessage({command: 'set-tspClient', data: getTspClientUrl()});
 	            }
 	            this.loadTheme();
 	            return;

--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -76,7 +76,11 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
               this.doHandleExperimentSetSignal(convertSignalExperiment(JSONBig.parse(message.data)));
               break;
           case 'set-tspClient':
-              this.setState({tspClient: new TspClient(message.data)});
+              this.setState({tspClient: new TspClient(message.data)}, () => {
+                  if (message.experiment) {
+                      this.doHandleExperimentSetSignal(convertSignalExperiment(JSONBig.parse(message.experiment)));
+                  }
+              });
               break;
           case 'add-output':
               // FIXME: JSONBig.parse() create bigint if numbers are small


### PR DESCRIPTION
When running in Theia, the set-tspClient and set-experiment are received right after each other and the setting of the tspClient in the state has not been finalized since it's done asynchronously. So, when the set-experiment signal is handled the tspClient in the react state is still undefined and the available outputs cannot be retrieved and hence no overview is shown.

The solution is to provide the experiment in the set-tspClient signal if available and hence the outputs can be retrieved and the overview view can be populated.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>