### PR TITLE
opened-traces: Remove redundant case code lines

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -87,11 +87,6 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
 	            }
 	            return;
 	        case 'closeTrace':
-	            if (message.data && message.data.wrapper) {
-	                TraceViewerPanel.disposePanel(this._extensionUri, JSONBig.parse(message.data.wrapper).name);
-	                signalManager().fireExperimentSelectedSignal(undefined);
-	            }
-	            return;
 	        case 'deleteTrace':
 	            if (message.data && message.data.wrapper) {
 	                // just remove the panel here


### PR DESCRIPTION
- Remove the `closeTrace` case lines of code, falling through `deleteTrace`'s which are identical.
- Based on the related SonarLint warning in VS Code.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>