### PR TITLE
webpack config: Remove obsoleted/extra devtool key

### DIFF
--- a/vscode-trace-webviews/webpack.config.js
+++ b/vscode-trace-webviews/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
     path: path.resolve(__dirname, "../vscode-trace-extension/pack"),
     filename: "[name].js"
   },
-  devtool: "eval-source-map",
   devtool: "inline-source-map",
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".json"]


### PR DESCRIPTION
- Since commit `1287ba25` introduced the currently required `"inline-source-map"` value for that key.
- The other, earlier commit `16fe6129` initialized that key prior, to a previously wanted value.
- This fix is also based on the related SonarLint warning in VS Code.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>