### PR TITLE
launch.json: Remove disallowed stopOnEntry property

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,8 +13,7 @@
             "outFiles": [
                 "${workspaceFolder}/vscode-trace-extension/pack/*.js",
                 "${workspaceFolder}/vscode-trace-extension/lib/**/*.js"
-            ],            
-            "stopOnEntry": false,
+            ],
             "sourceMaps": true
         }
     ]


### PR DESCRIPTION
This property was highlighted as disallowed, by VS Code/Codium locally.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>