### PR TITLE
Render new trace server connection status bar item

### DIFF
--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -5,15 +5,21 @@ import { TraceExplorerItemPropertiesProvider } from './trace-explorer/properties
 import { TraceExplorerAvailableViewsProvider } from './trace-explorer/available-views/trace-explorer-available-views-webview-provider';
 import { TraceExplorerOpenedTracesViewProvider } from './trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider';
 import { fileHandler, openOverviewHandler, resetZoomHandler } from './trace-explorer/trace-tree';
+import { TraceServerConnectionStatusService } from './utils/trace-server-status';
 import { updateTspClient } from './utils/tspClient';
 
 export function activate(context: vscode.ExtensionContext): void {
 
-    const tracesProvider = new TraceExplorerOpenedTracesViewProvider(context.extensionUri);
+    const serverStatusBarItemPriority = 1;
+    const serverStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, serverStatusBarItemPriority);
+    context.subscriptions.push(serverStatusBarItem);
+    const serverStatusService = new TraceServerConnectionStatusService(serverStatusBarItem);
+
+    const tracesProvider = new TraceExplorerOpenedTracesViewProvider(context.extensionUri, serverStatusService);
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(TraceExplorerOpenedTracesViewProvider.viewType, tracesProvider));
 
-    const myAnalysisProvider = new TraceExplorerAvailableViewsProvider(context.extensionUri);
+    const myAnalysisProvider = new TraceExplorerAvailableViewsProvider(context.extensionUri, serverStatusService);
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(TraceExplorerAvailableViewsProvider.viewType, myAnalysisProvider));
 

--- a/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
@@ -4,6 +4,7 @@ import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import * as vscode from 'vscode';
 import { TraceViewerPanel } from '../../trace-viewer-panel/trace-viewer-webview-panel';
+import { TraceServerConnectionStatusService } from '../../utils/trace-server-status';
 import { getTraceServerUrl, getTspClientUrl } from '../../utils/tspClient';
 import { convertSignalExperiment } from 'vscode-trace-extension/src/common/signal-converter';
 
@@ -24,6 +25,7 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
 
 	constructor(
 		private readonly _extensionUri: vscode.Uri,
+		private readonly _statusService: TraceServerConnectionStatusService,
 	) { }
 
 	public resolveWebviewView(
@@ -47,6 +49,12 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
 	    // Handle messages from the webview
 	    webviewView.webview.onDidReceiveMessage(message => {
 	        switch (message.command) {
+	        case 'connectionStatus':
+	            if (message.data && message.data.status) {
+	                const status: boolean = JSON.parse(message.data.status);
+	                this._statusService.render(status);
+	            }
+	            return;
 	        case 'webviewReady':
 	            // Post the tspTypescriptClient
 	            webviewView.webview.postMessage({command: 'set-tspClient', data: getTspClientUrl()});

--- a/vscode-trace-extension/src/trace-explorer/trace-tree.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-tree.ts
@@ -137,7 +137,7 @@ export const fileHandler = (analysisTree: AnalysisProvider) => async (context: v
         const fileStat = await vscode.workspace.fs.stat(traceUri);
         if (fileStat) {
             if (fileStat.type === vscode.FileType.Directory) {
-                // Find recursivly CTF traces
+                // Find recursively CTF traces
                 const foundTraces = await findTraces(uri);
                 foundTraces.forEach(trace => tracesArray.push(trace));
             } else {
@@ -175,7 +175,7 @@ const findTraces = async (directory: string): Promise<string[]> => {
     const uri = vscode.Uri.file(directory);
     /**
     * If single file selection then return single trace in traces, if directory then find
-    * recoursivly CTF traces in starting from root directory.
+    * recursively CTF traces in starting from root directory.
     */
     const ctf = await isCtf(directory);
     if (ctf) {

--- a/vscode-trace-extension/src/trace-explorer/trace-tree.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-tree.ts
@@ -73,7 +73,7 @@ export class Trace extends vscode.TreeItem {
 }
 
 export const traceHandler = (analysisTree: AnalysisProvider) => (context: vscode.ExtensionContext, trace: Trace): void => {
-    const panel = TraceViewerPanel.createOrShow(context.extensionUri, trace.name);
+    const panel = TraceViewerPanel.createOrShow(context.extensionUri, trace.name, undefined);
     (async () => {
         const traces = new Array<TspTrace>();
         const t = await traceManager.openTrace(trace.uri, trace.name);
@@ -127,7 +127,7 @@ export const fileHandler = (analysisTree: AnalysisProvider) => async (context: v
         return;
     }
     const name = uri.substring(uri.lastIndexOf('/') + 1);
-    const panel = TraceViewerPanel.createOrShow(context.extensionUri, name);
+    const panel = TraceViewerPanel.createOrShow(context.extensionUri, name, undefined);
     (async () => {
 
         /*

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -11,7 +11,7 @@ const JSONBig = JSONBigConfig({
     useNativeBigInt: true,
 });
 
-// TODO: manage mutiple panels (currently just a hack around, need to be fixed)
+// TODO: manage multiple panels (currently just a hack around, need to be fixed)
 
 /**
  * Manages react webview panels
@@ -107,7 +107,7 @@ export class TraceViewerPanel {
 		    retainContextWhenHidden: true,
 	        enableCommandUris: true,
 
-	        // And restric the webview to only loading content from our extension's `media` directory.
+	        // And restrict the webview to only loading content from our extension's `media` directory.
 	        localResourceRoots: [
 	            vscode.Uri.joinPath(this._extensionUri, 'pack')
 	        ]
@@ -117,7 +117,7 @@ export class TraceViewerPanel {
 	    this._panel.webview.html = this._getHtmlForWebview();
 
 	    // Listen for when the panel is disposed
-	    // This happens when the user closes the panel or when the panel is closed programatically
+	    // This happens when the user closes the panel or when the panel is closed programmatically
 	    this._panel.onDidDispose(() => {
 	        this.dispose();
 	        TraceViewerPanel.activePanels[name] = undefined;

--- a/vscode-trace-extension/src/utils/trace-server-status.ts
+++ b/vscode-trace-extension/src/utils/trace-server-status.ts
@@ -1,0 +1,24 @@
+import { StatusBarItem, ThemeColor } from 'vscode';
+
+export class TraceServerConnectionStatusService {
+
+    private statusBarItem: StatusBarItem;
+
+    public constructor(statusBarItem: StatusBarItem) {
+        this.statusBarItem = statusBarItem;
+        this.statusBarItem.hide();
+    }
+
+    public async render(status: boolean): Promise<void> {
+        if (status) {
+            this.statusBarItem.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
+            this.statusBarItem.text = '$(check) Trace Server';
+            this.statusBarItem.tooltip = 'Trace Viewer: server found';
+        } else {
+            this.statusBarItem.backgroundColor = new ThemeColor('statusBarItem.errorBackground');
+            this.statusBarItem.text = '$(error) Trace Server';
+            this.statusBarItem.tooltip = 'Trace Viewer: server not found';
+        }
+        this.statusBarItem.show();
+    }
+}

--- a/vscode-trace-webviews/src/common/tsp-client-provider-impl.ts
+++ b/vscode-trace-webviews/src/common/tsp-client-provider-impl.ts
@@ -1,20 +1,30 @@
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
+import { RestClient, ConnectionStatusListener } from 'tsp-typescript-client/lib/protocol/rest-client';
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
+import { VsCodeMessageManager } from './vscode-message-manager';
 
 export class TspClientProvider implements ITspClientProvider {
 
     private _tspClient: TspClient;
     private _traceManager: TraceManager;
     private _experimentManager: ExperimentManager;
+    private _signalHandler: VsCodeMessageManager;
+    private _statusListener: ConnectionStatusListener;
     // private _listeners: ((tspClient: TspClient) => void)[];
 
-    constructor(traceServerUrl: string
+    constructor(traceServerUrl: string, signalHandler: VsCodeMessageManager
     ) {
         this._tspClient = new TspClient(traceServerUrl);
         this._traceManager = new TraceManager(this._tspClient);
         this._experimentManager = new ExperimentManager(this._tspClient, this._traceManager);
+
+        this._signalHandler = signalHandler;
+        this._statusListener = ((status: boolean) => {
+            this._signalHandler.notifyConnection(status);
+        });
+        RestClient.addConnectionStatusListener(this._statusListener);
         // this._listeners = [];
         // tspUrlProvider.addTraceServerUrlChangedListener(url => {
         //     this._tspClient = new TspClient(url);

--- a/vscode-trace-webviews/src/common/vscode-message-manager.ts
+++ b/vscode-trace-webviews/src/common/vscode-message-manager.ts
@@ -21,7 +21,6 @@ export interface VsCodeTraceAction {
 }
 
 export class VsCodeMessageManager extends Messages.MessageManager {
-
     constructor() {
         super();
     }
@@ -40,9 +39,15 @@ export class VsCodeMessageManager extends Messages.MessageManager {
         vscode.postMessage({command: 'webviewReady'});
     }
 
+    notifyConnection(serverStatus: boolean): void {
+        const status: string = JSON.stringify(serverStatus);
+        vscode.postMessage({command: 'connectionStatus', data: { status }});
+    }
+
     /**************************************************************************
      * Trace Explorer React APP
      *************************************************************************/
+
     reOpenTrace(experiment: Experiment): void {
         const wrapper: string = JSONBig.stringify(experiment);
         vscode.postMessage({command: 'reopenTrace', data: {wrapper}});

--- a/vscode-trace-webviews/src/common/vscode-message-manager.ts
+++ b/vscode-trace-webviews/src/common/vscode-message-manager.ts
@@ -15,7 +15,7 @@ interface vscode {
 // declare function acquireVsCodeApi(): vscode;
 declare const vscode: vscode;
 
-export interface VsCodeTraceAtion {
+export interface VsCodeTraceAction {
     actionId: string;
     args: any[];
 }

--- a/vscode-trace-webviews/src/trace-explorer/available-views/vscode-trace-explorer-views-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/available-views/vscode-trace-explorer-views-widget.tsx
@@ -41,7 +41,7 @@ class TraceExplorerViewsWidget extends React.Component<{}, AvailableViewsAppStat
           const message = event.data; // The JSON data our extension sent
           switch (message.command) {
           case 'set-tspClient':
-              this.setState({ tspClientProvider: new TspClientProvider(message.data) });
+              this.setState({ tspClientProvider: new TspClientProvider(message.data, this._signalHandler) });
               break;
           case 'experimentSelected':
               let experiment: Experiment | undefined = undefined;

--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -43,7 +43,7 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
           const message = event.data; // The JSON data our extension sent
           switch (message.command) {
           case 'set-tspClient':
-              const tspClientProvider: ITspClientProvider = new TspClientProvider(message.data);
+              const tspClientProvider: ITspClientProvider = new TspClientProvider(message.data, this._signalHandler);
               this._experimentManager = tspClientProvider.getExperimentManager();
               this.setState({ tspClientProvider: tspClientProvider });
               if (this.state.tspClientProvider) {


### PR DESCRIPTION
Add a contextual (secondary, right-side) VS Code status bar item, that renders the current trace server status. Have the extension context pass this status service to each active web-view provider, for them to update the rendered status upon every related message from the view.

Have `TraceExplorerOpenedTracesViewProvider` pass its status service to the `TraceViewerPanel` upon using it, in turn. Without this, there are instances where the latest server status isn't shown as expected. Keep this undefined in `trace-tree.ts` where that is not required.

This makes the server status listener-based. Add this connection listener through the `TspClientProvider` constructor, thus consistently use the latter across. This means also using it in the `TraceViewerContainer` constructor, instead of `TspClient`'s directly prior.

Properly `stringify` (thus parse) the boolean status value, as passing it straight would break the JSON message otherwise.

Explicitly defer showing the item to only once Trace Viewer gets selected for the first time. Like open trace-explorer views which remain shown if unselecting Trace Viewer, keep showing the status item from there on. The VS Code API, anyway, doesn't hold an event that could selectively hide anything upon solely exiting Trace Viewer.

Prefer a standard VS Code status bar item to the side widget approach of `theia-trace-extension`. This should be more standard for such a connection status display, from a VS Code UI (and UX) perspective. This also allows not having to implement a custom widget that differs from the Trace Viewer panels. -The latter being meant to render real views.

Base this simple design of the status bar item on [1] below. Now, use the warning background for a found server, for such a positive status to be highlighted, thus noticeable. Use the usual red background for a trace server that is not found, highlighting that as an error. No other color can or should be used anyway for status bar items, per [1]. The latter reference also includes [2]'s, used to come up with this change.

[1]https://code.visualstudio.com/api/ux-guidelines/status-bar
[2]https://github.com/microsoft/vscode-extension-samples/blob/main/statusbar-sample/src/extension.ts

Use a short (thus usable) enough `statusBarItem.text`, along with a `tooltip` to complement the trace server status narrative.

Overall, with this approach, defer the introduction of the `inversify` module, used in `theia-trace-extension`. This would be to inject instances such as objects involved in this change and likely other ones; some being potential singletons.

Slightly refactor a few surrounding blank lines while editing some of these files.

Fixes #33.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>