### PR TITLE
extension: Add Start/Stop Trace Server commands (WIP)

### DIFF
--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -46,6 +46,14 @@
         "command": "openedTraces.openTraceFolder",
         "title": "Open Trace",
         "icon": "$(new-folder)"
+      },
+      {
+        "command": "traceServer.start",
+        "title": "Start Trace Server"
+      },
+      {
+        "command": "traceServer.stop",
+        "title": "Stop Trace Server"
       }
     ],
     "viewsContainers": {
@@ -145,6 +153,7 @@
     "terser": "4.8.1",
     "traceviewer-base": "next",
     "traceviewer-react-components": "next",
+    "tree-kill": "latest",
     "vsce": "^1.85.1",
     "vscode-trace-webviews": "0.0.0"
   },

--- a/vscode-trace-extension/src/utils/trace-server-service.ts
+++ b/vscode-trace-extension/src/utils/trace-server-service.ts
@@ -1,0 +1,26 @@
+import { ChildProcess, spawn } from 'child_process';
+import treeKill from 'tree-kill';
+
+// TODO: Finish implementing this class based on [1,2] right below.
+// [1] theia-trace-extension/theia-extensions/viewer-prototype/src/node/trace-server/trace-server-service.ts
+// [2] https://nodejs.org/api/child_process.html
+export class TraceServerService {
+
+    private server: ChildProcess;
+
+    async startTraceServer(): Promise<void> {
+        // TODO: Revisit the 2 children being detached only to support the process.kill call below.
+        this.server = spawn('/usr/bin/tracecompass-server', { detached: true }); // Configure path!
+    }
+
+    async stopTraceServer(): Promise<void> {
+        await new Promise<void>(() => {
+            treeKill(this.server.pid);
+        });
+    }
+
+    stopTraceServerNow(): void {
+        // TODO: Likely works only on Linux; kills both server processes (child, sub-child).
+        process.kill(-this.server.pid); // Known as "the PID hack"; treeKill failed on Exit.
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8408,6 +8408,11 @@ traceviewer-react-components@next:
     traceviewer-base "0.2.0-next.3ebd9d7.0+3ebd9d7"
     tsp-typescript-client next
 
+tree-kill@latest:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"


### PR DESCRIPTION
This is a WIP, to likely require introducing a back-end that may locally or remotely hold the `trace-server`.
- The latter's path and arguments are to be made configurable,
- and shall be also started upon opening traces, if otherwise stopped.
- Properly stopping it on exit/quit is as required.

Include the related `TODO` lines and side comments as a list of WIP tasks.

Contributes to fixing (Fixes?) #15.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>