### PR TITLE
Configure integration tests with Playwright

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build-and-test:
+  build:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -43,6 +43,41 @@ jobs:
           ${{ runner.os }}-yarn-
 
     - run: yarn --frozen-lockfile
+
+  ui-test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: yarn
+    - name: Package VS Code Extension
+      run: yarn vsce:package
+    - name: Download sample traces
+      run: yarn download:sample-traces
+    - name: Download trace server
+      run: yarn download:server
+    - name: Start trace server
+      run: yarn start:server &
+    - name: Download openvscode-server
+      run: yarn download:openvscode-server
+    - name: Configure openvscode-server
+      run: yarn configure:openvscode-server
+    - name: Start openvscode-server
+      run: yarn start:openvscode-server &
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30
 
   code-lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ node_modules/
 # testing
 coverage/
 .vscode-test/
+test-resources/
+test-results/
+playwright-report/
+playwright/.cache/
+salt
 
 # production
 lib/

--- a/README.md
+++ b/README.md
@@ -159,6 +159,49 @@ To get sample traces to try run the following command. The traces will be stored
 yarn download:sample-traces
 ```
 
+## Running UI tests
+
+To run the UI tests locally, use the following commands.
+
+Steps for setup that only need to be run once:
+
+```bash
+yarn download:sample-traces
+yarn download:server
+yarn download:openvscode-server
+yarn configure:openvscode-server
+yarn playwright install --with-deps
+```
+
+Steps to run once and again every time the application code is modified:
+
+```bash
+yarn
+yarn vsce:package
+# kill openvscode-server if running and restart it below
+```
+
+Steps to run once if the corresponding server is not already running:
+
+```bash
+yarn start:server & # or run in a separate shell
+yarn start:openvscode-server & # or run in a separate shell
+```
+
+To run or re-run the tests after test code is modified:
+
+```bash
+yarn playwright test
+```
+
+To test in debug mode, test with tracing on, or test with retries on failure, use the following options:
+
+```bash
+yarn playwright test --debug
+yarn playwright test --trace on
+yarn playwright test --retries <retries>
+```
+
 [init-contrib]: https://github.com/eclipse-cdt-cloud/theia-trace-extension/pull/124
 [install]: https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix
 [open-output]: https://raw.githubusercontent.com/eclipse-cdt-cloud/vscode-trace-extension/master/doc/images/vscode-trace-extension-001.png

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "lint": "lerna run lint",
     "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
     "start:server": "./trace-compass-server/tracecompass-server",
-    "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/dorsal-lab/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz"
+    "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/dorsal-lab/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz",
+    "download:openvscode-server": "mkdir -p test-resources; cd test-resources; curl -L -o openvscode-server-v1.77.3-linux-x64.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.77.3/openvscode-server-v1.77.3-linux-x64.tar.gz; tar -xf openvscode-server-v1.77.3-linux-x64.tar.gz",
+    "configure:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; sed -i 's;\"$@\".*$;\"$@\" --without-connection-token --install-extension $ROOT/../../vscode-trace-extension/vscode-trace-extension-0.1.0.vsix --default-folder=$ROOT/../../TraceCompassTutorialTraces --start-server;g' openvscode-server",
+    "start:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; ./openvscode-server ${0}"
   },
   "devDependencies": {
     "lerna": "^3.20.2"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './vscode-trace-extension/src/test/',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    }
+  ]
+});

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -149,24 +149,25 @@
     "vscode-trace-webviews": "0.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.32.3",
     "@types/jest": "^23.3.13",
     "@types/json-bigint": "^1.0.1",
     "@types/node": "^10.1.2",
     "@types/vscode": "^1.52.0",
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/parser": "^3.4.0",
-    "rimraf": "^2.6.3",
-    "source-map-loader": "^1.0.2",
     "css-loader": "^5.0.1",
-    "rewire": "^4.0.1",
-    "style-loader": "^2.0.0",
-    "svg-url-loader": "^7.1.1",
-    "ts-loader": "^8.0.14",
-    "typescript": "^4.1.3",
     "eslint": "^7.3.0",
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-no-null": "^1.0.2",
-    "eslint-plugin-react": "^7.20.0"
+    "eslint-plugin-react": "^7.20.0",
+    "rewire": "^4.0.1",
+    "rimraf": "^2.6.3",
+    "source-map-loader": "^1.0.2",
+    "style-loader": "^2.0.0",
+    "svg-url-loader": "^7.1.1",
+    "ts-loader": "^8.0.14",
+    "typescript": "^4.1.3"
   },
   "resolutions": {
     "terser": "3.14.1",

--- a/vscode-trace-extension/src/test/extension-test.spec.ts
+++ b/vscode-trace-extension/src/test/extension-test.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000');
+    await page.getByRole('tab', { name: 'Welcome, preview' }).getByRole('button', { name: /Close/ }).click();
+    await page.getByRole('button', { name: 'Never' }).click();
+});
+
+test('Open Trace from Explorer', async ({ page }) => {
+    await page.getByRole('treeitem', { name: '202-bug-hunt' }).locator('a').click();
+    await page.getByRole('treeitem', { name: 'cat-kernel' }).locator('a').click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Open with Trace Viewer' }).hover();
+    await page.getByRole('menuitem', { name: 'Open with Trace Viewer' }).click();
+    await expect(page.getByRole('tab', { name: 'cat-kernel'})).toBeVisible();
+});
+
+test('Open Trace from Trace Viewer', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Trace Viewer' }).locator('a').click();
+    await page.getByRole('button', { name: 'Opened Traces Section' }).hover();
+    await page.getByRole('button', { name: 'Open Trace' }).click();
+    await page.getByRole('option', { name: '202-bug-hunt' }).locator('a').click();
+    await page.getByRole('option', { name: 'cat-kernel' }).locator('a').click();
+    await page.waitForTimeout(1000);
+    await page.getByRole('button', { name: 'OK' }).click();
+    await expect(page.getByRole('tab', { name: 'cat-kernel'})).toBeVisible();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,9 +177,9 @@
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@jridgewell/gen-mapping@^0.3.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -196,22 +196,35 @@
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
 "@jridgewell/source-map@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
-  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.3.tgz#8108265659d4c33e72ffe14e33d6cc5eb59f2fda"
+  integrity sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+"@jridgewell/sourcemap-codec@1.4.14":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.14":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
@@ -1433,6 +1446,16 @@
     earcut "^2.1.5"
     eventemitter3 "^3.1.0"
     url "^0.11.0"
+
+"@playwright/test@^1.32.3":
+  version "1.32.3"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.32.3.tgz#75be8346d4ef289896835e1d2a86fdbe3d9be92a"
+  integrity sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.32.3"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 "@semantic-ui-react/event-stack@^3.1.0":
   version "3.1.3"
@@ -4253,6 +4276,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -6719,6 +6747,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+playwright-core@1.32.3:
+  version "1.32.3"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.3.tgz#e6dc7db0b49e9b6c0b8073c4a2d789a96f519c48"
+  integrity sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -8236,9 +8269,9 @@ terser@4.8.1:
     source-map-support "~0.5.12"
 
 terser@^5.14.1:
-  version "5.16.6"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.6.tgz#f6c7a14a378ee0630fbe3ac8d1f41b4681109533"
-  integrity sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==
+  version "5.16.9"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.9.tgz#7a28cb178e330c484369886f2afd623d9847495f"
+  integrity sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
Add and configure Playwright in vscode-trace-extension package.

Add extension-test.spec.ts with a few simple tests.

Ignore and exclude test files and folders from build and version control.

Partially fixes Issue #34