### PR TITLE
Added an output channel for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ The react-app is another matter. The panel is a webview that is running in its o
 
 Each panel is its own small web application, so to debug, while in the context of the webview, press `ctrl-shift-p` and enter the command `Developer: Open Webview Developer Tools`. This will open the developer tools. The code is in the `Sources` tab of the developer tools window that opens.
 
+### Logging in the extension
+
+The extension uses an output channel for logging. To view the logs, navigate to the output panel. The output panel can be accessed by navigating to view -> open view -> type 'output'. To open the extension output channel, navigate the drop down option and look for `Trace Extension`. An alternate way of opening the trace extension output channel is through command palette. Open command palette by pressing `ctrl-shift-p`, and then run `Output: Show Output Channels...\`. This will prompt a list of available outputs. Select `Trace Extension` from the list of available outputs.
+
+For logging to the `Trace Extension` output channel, use the `traceLogger` object instantiated in `extension.ts`. The following are examples of using the log channel:
+
+```javascript
+traceLogger.addLogMessage('Hello from trace extension without tag');
+```
+
+This will add the following log entry in the output channel:
+```text
+[2023-04-25 11:07:22.500] Hello from trace extension without tag
+```
+
+```javascript
+traceLogger.addLogMessage('Hello from trace extension with tag', 'tag');
+```
+
+This will add the following log entry in the output channel:
+```text
+[2023-04-25 11:08:40.500] [tag] Hello from trace extension with tag
+```
+
 ### Troubleshooting
 
 *The `Trace Viewer` panel is not there, or disappears when switching panel.

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -6,8 +6,12 @@ import { TraceExplorerAvailableViewsProvider } from './trace-explorer/available-
 import { TraceExplorerOpenedTracesViewProvider } from './trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider';
 import { fileHandler, openOverviewHandler, resetZoomHandler } from './trace-explorer/trace-tree';
 import { updateTspClient } from './utils/tspClient';
+import { TraceExtensionLogger } from './utils/trace-extension-logger';
+
+export let traceLogger: TraceExtensionLogger;
 
 export function activate(context: vscode.ExtensionContext): void {
+    traceLogger = new TraceExtensionLogger('Trace Extension');
 
     const tracesProvider = new TraceExplorerOpenedTracesViewProvider(context.extensionUri);
     context.subscriptions.push(
@@ -55,4 +59,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('openedTraces.openTraceFolder', () => {
         fileOpenHandler(context, undefined);
     }));
+}
+
+export function deactivate(): void {
+    traceLogger.disposeChannel();
 }

--- a/vscode-trace-extension/src/utils/trace-extension-logger.ts
+++ b/vscode-trace-extension/src/utils/trace-extension-logger.ts
@@ -1,0 +1,189 @@
+/***************************************************************************************
+ * Copyright (c) 2023 BlackBerry Limited and others.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ ***************************************************************************************/
+
+import * as vscode from 'vscode';
+
+export class TraceExtensionLogger {
+    private logChannel: vscode.OutputChannel;
+    private channelDisposed = true;
+
+    constructor(logChannelName: string) {
+        this.logChannel = vscode.window.createOutputChannel(logChannelName);
+        this.channelDisposed = false;
+    }
+
+    /**
+     * Returns the status of the log output channel
+     *
+     * @returns true if the current channel has been disposed, false otherwise
+     */
+    isCurrentChannelDisposed(): boolean {
+        return this.channelDisposed;
+    }
+
+    /**
+     * Show the log channel from the UI
+     */
+    showLog(): void {
+        if (!this.isCurrentChannelDisposed()) {
+            this.logChannel.show();
+        }
+    }
+
+    /**
+     * Hide the log channel from the UI
+     */
+    hideLog(): void {
+        if (!this.isCurrentChannelDisposed()) {
+            this.logChannel.hide();
+        }
+    }
+
+    /**
+     * Clears the entries from the log channel
+     */
+    clearLog(): void {
+        if (!this.isCurrentChannelDisposed()) {
+            this.logChannel.clear();
+        }
+    }
+
+    /**
+     * Disposes the log channel and all of its resources
+     */
+    disposeChannel(): void {
+        if (!this.isCurrentChannelDisposed()) {
+            this.logChannel.dispose();
+            this.channelDisposed = true;
+        }
+    }
+
+    /**
+     * Adds a log entry to the log channel with an optional tag
+     *
+     * @param message message to be appended to the log channel
+     * @param tag appended to the front of the message (i.e. [$tag] $message)
+     */
+    addLogMessage(message: string, tag?: string): void {
+        let fullMessage: string;
+        if (tag) {
+            fullMessage = '[' + tag + '] ' + message;
+        } else {
+            fullMessage = message;
+        }
+        this.addLogPanelMessage(fullMessage);
+    }
+
+    /**
+     * Adds a log entry for an error.
+     * Prints the error message and the stack
+     *
+     * @param e error to be appended to the log channel
+     */
+    logError(e: Error): void {
+        this.addLogMessage(e.message);
+        if (e.stack) {
+            this.addLogMessage(e.stack);
+        }
+    }
+
+    /**
+     * Shows an information message to user as a notification and
+     * adds the message to the log channel
+     *
+     * @param message information message to show to the user and add to the log channel
+     * @param options Configures the behavior of the message
+     * @returns void promise
+     */
+    async showInfo(message: string, options?: vscode.MessageOptions): Promise<void> {
+        const fullMessage = 'Info: ' + message;
+        vscode.window.showInformationMessage(fullMessage, options || { modal: false });
+        return this.addLogMessage(fullMessage);
+    }
+
+    /**
+     * Shows a warning message to user as a notification and
+     * adds the message to the log channel
+     *
+     * @param message warning message to show to the user and add to the log channel
+     * @param options Configures the behavior of the message
+     * @returns void promise
+     */
+    async showWarning(message: string, options?: vscode.MessageOptions): Promise<void> {
+        const fullMessage = 'Warning: ' + message;
+        vscode.window.showWarningMessage(fullMessage, options || { modal: false });
+        return this.addLogMessage(fullMessage);
+    }
+
+    /**
+     * Shows an error message to user as a notification and
+     * adds the message to the log channel
+     *
+     * @param message error message to show to the user and add to the log channel
+     * @param options Configures the behavior of the message
+     * @returns void promise
+     */
+    async showError(message: string, options?: vscode.MessageOptions): Promise<void> {
+        const fullMessage = 'Error: ' + message;
+        vscode.window.showErrorMessage(fullMessage, options || { modal: false });
+        return this.addLogMessage(fullMessage);
+    }
+
+    /**
+     * Appends the message with a timestamp to the log channel
+     *
+     * @param message message to be added to the log channel
+     */
+    private addLogPanelMessage(message: string) {
+        if (!this.isCurrentChannelDisposed()) {
+            this.logChannel.append(`[${this.getTimestamp()}] ${message}\n`);
+        }
+    }
+
+    /**
+     * Gets the current formatted timestamp
+     *
+     * @returns formatted timestamp
+     */
+    private getTimestamp(): string {
+        const date = new Date();
+        return (
+            date.getFullYear() +
+            '-' +
+            this.padTwoDigits(date.getMonth() + 1) +
+            '-' +
+            this.padTwoDigits(date.getDate()) +
+            ' ' +
+            this.padTwoDigits(date.getHours()) +
+            ':' +
+            this.padTwoDigits(date.getMinutes()) +
+            ':' +
+            this.padTwoDigits(date.getSeconds()) +
+            '.' +
+            this.padThreeDigits(date.getMilliseconds())
+        );
+    }
+
+    /**
+     * Pad a number with a leading zero if it is less than two digits long.
+     *
+     * @param n Number to be padded
+     * @returns Number that is padded with leading zeros
+     */
+    private padTwoDigits(n: number): string {
+        return (n > 9 ? '' : '0') + n;
+    }
+
+    /**
+     * If a number is less than three digits, the number will be padded with leading zeros
+     *
+     * @param n Number to be padded
+     * @returns Number that is padded with leading zeros
+     */
+    private padThreeDigits(n: number): string {
+        return (n > 99 ? '' : n > 9 ? '0' : '00') + n;
+    }
+}


### PR DESCRIPTION
This will create an output channel for the trace extension 
in the output panel of vscode. This can be used to provide 
information to users.

Signed-off-by: Neel Gondalia ngondalia@blackberry.com