### PR TITLE
Show placeholder view when no experiments are open

### DIFF
--- a/vscode-trace-common/src/messages/vscode-message-manager.ts
+++ b/vscode-trace-common/src/messages/vscode-message-manager.ts
@@ -45,7 +45,8 @@ export const VSCODE_MESSAGES = {
     WEBVIEW_READY: 'webviewReady',
     UNDO: 'undo',
     REDO: 'redo',
-    UPDATE_ZOOM: 'updateZoom'
+    UPDATE_ZOOM: 'updateZoom',
+    OPEN_TRACE: 'openTrace'
 };
 
 export class VsCodeMessageManager extends Messages.MessageManager {
@@ -75,6 +76,14 @@ export class VsCodeMessageManager extends Messages.MessageManager {
     /**************************************************************************
      * Trace Explorer React APP
      *************************************************************************/
+
+    openTrace(): void {
+        vscode.postMessage({command: VSCODE_MESSAGES.OPEN_TRACE});
+    }
+
+    updateOpenedTraces(numberOfOpenedTraces: number): void {
+        vscode.postMessage({command: VSCODE_MESSAGES.OPENED_TRACES_UPDATED, numberOfOpenedTraces});
+    }
 
     reOpenTrace(experiment: Experiment): void {
         const wrapper: string = JSONBig.stringify(experiment);

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -109,12 +109,14 @@
         {
           "type": "webview",
           "id": "traceExplorer.availableViews",
-          "name": "Views"
+          "name": "Views",
+          "when": "!trace-explorer.noExperiments"
         },
         {
           "type": "webview",
           "id": "traceExplorer.itemPropertiesView",
-          "name": "Item Properties"
+          "name": "Item Properties",
+          "when": "!trace-explorer.noExperiments"
         }
       ]
     },
@@ -136,7 +138,7 @@
       "view/title": [
         {
           "command": "openedTraces.openTraceFolder",
-          "when": "view == traceExplorer.openedTracesView",
+          "when": "view == traceExplorer.openedTracesView && !trace-explorer.noExperiments",
           "group": "navigation"
         }
       ],

--- a/vscode-trace-webviews/src/style/trace-viewer.css
+++ b/vscode-trace-webviews/src/style/trace-viewer.css
@@ -33,4 +33,8 @@
     --trace-viewer-button-background: var(--vscode-button-background);
     --trace-viewer-ui-padding: 6px;
     --trace-viewer-list-line-height: 16px;
+    --trace-viewer-secondaryButton-foreground: var(--vscode-button-secondaryForeground);
+    --trace-viewer-secondaryButton-background: var(--vscode-button-secondaryBackground);
+    --trace-viewer-sideBar-foreground: var(--vscode-sideBarTitle-foreground);
+    --trace-viewer-button-foreground: var(--vscode-button-foreground);
 }


### PR DESCRIPTION
- Trace explorer panel provides an open trace button when experiments are 0
- Available views and properties webviews are hidden when experiments are 0
- Show the above 2 webviews when user opens an experiment

Fixes #110 