### PR TITLE
README: Fix markdownlint about missing blank lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ traceLogger.addLogMessage('Hello from trace extension without tag');
 ```
 
 This will add the following log entry in the output channel:
+
 ```text
 [2023-04-25 11:07:22.500] Hello from trace extension without tag
 ```
@@ -126,6 +127,7 @@ traceLogger.addLogMessage('Hello from trace extension with tag', 'tag');
 ```
 
 This will add the following log entry in the output channel:
+
 ```text
 [2023-04-25 11:08:40.500] [tag] Hello from trace extension with tag
 ```


### PR DESCRIPTION
Fix the two markdownlint warnings [1] below, in VS Cod{e|ium}.

[1] MD031: Fenced code blocks should be surrounded by blank lines.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>