### PR TITLE
Fix padding of placeholder message

### DIFF
--- a/vscode-trace-webviews/src/trace-viewer/index.css
+++ b/vscode-trace-webviews/src/trace-viewer/index.css
@@ -1,5 +1,12 @@
 body {
+  height: 100%;
   margin: 0;
   padding: 0;
   font-family: sans-serif;
+}
+
+#root {
+  height: 100%;
+  width: 100%;
+  position: absolute;
 }


### PR DESCRIPTION
The body and root div were not filling 100% of the height.  This led to problems displaying the placeholder message when a user hasn't selected any outputs.

Makes body and root div height and width 100%.  Centers the placeholder message on the screen.  Fixes #112.