### PR TITLE
extension: Support hidden server status commands

### DIFF
--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -80,6 +80,14 @@
         "command": "traceViewer.shortcuts",
         "title": "Trace Viewer Keyboard and Mouse Shortcuts",
         "icon": "$(info)"
+      },
+      {
+        "command": "serverStatus.started",
+        "title": "Trace Server: started"
+      },
+      {
+        "command": "serverStatus.stopped",
+        "title": "Trace Server: stopped"
       }
     ],
     "viewsContainers": {
@@ -173,6 +181,16 @@
           "when": "activeWebviewPanelId == 'react'",
           "command": "traceViewer.shortcuts",
           "group": "navigation@7"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "serverStatus.started",
+          "when": "false"
+        },
+        {
+          "command": "serverStatus.stopped",
+          "when": "false"
         }
       ]
     },

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -85,6 +85,14 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('traceViewer.shortcuts', () => {
         keyboardShortcutsHandler(context.extensionUri);
     }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('serverStatus.started', () => {
+        serverStatusService.render(true);
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('serverStatus.stopped', () => {
+        serverStatusService.render(false);
+    }));
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
Add two commands for a sibling extension such as [1] to use.
- These two commands are hidden from the Command Palette,
- as meant for [1] to update the Trace Server status bar item upon confirmed server start/stop.

[1] https://github.com/eclipse-cdt-cloud/vscode-trace-server

Contributes to fixing Issue #15.

Signed-off-by: Marco Miller <marco.miller@ericsson.com>