### PR TITLE
Use constants for undo, redo and updateZoom vscode messages

### DIFF
--- a/vscode-trace-common/src/messages/vscode-message-manager.ts
+++ b/vscode-trace-common/src/messages/vscode-message-manager.ts
@@ -43,6 +43,9 @@ export const VSCODE_MESSAGES = {
     TRACE_VIEWER_TAB_ACTIVATED: 'traceViewerTabActivated',
     UPDATE_PROPERTIES: 'updateProperties',
     WEBVIEW_READY: 'webviewReady',
+    UNDO: 'undo',
+    REDO: 'redo',
+    UPDATE_ZOOM: 'updateZoom'
 };
 
 export class VsCodeMessageManager extends Messages.MessageManager {

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -247,14 +247,14 @@ export class TraceViewerPanel {
 
 	undoRedo(undo: boolean): void {
 	    if (undo) {
-	        this._panel.webview.postMessage({ command: 'undo' });
+	        this._panel.webview.postMessage({ command: VSCODE_MESSAGES.UNDO });
 	    } else {
-	        this._panel.webview.postMessage({ command: 'redo' });
+	        this._panel.webview.postMessage({ command: VSCODE_MESSAGES.REDO });
 	    }
 	}
 
 	updateZoom(hasZoomedIn: boolean): void {
-	    this._panel.webview.postMessage({ command: 'updateZoom', data: hasZoomedIn});
+	    this._panel.webview.postMessage({ command: VSCODE_MESSAGES.UPDATE_ZOOM, data: hasZoomedIn});
 	}
 
 	loadTheme(): void {

--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -102,13 +102,13 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
           case VSCODE_MESSAGES.RESET_ZOOM:
               this.resetZoom();
               break;
-          case 'undo':
+          case VSCODE_MESSAGES.UNDO:
               this.undo();
               break;
-          case 'redo':
+          case VSCODE_MESSAGES.REDO:
               this.redo();
               break;
-          case 'updateZoom':
+          case VSCODE_MESSAGES.UPDATE_ZOOM:
               this.updateZoom(message.data);
               break;
           }


### PR DESCRIPTION
Use constants for undo, redo and updateZoom vscode messages instead of hard-coded strings.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>