### PR TITLE
Add support for view markers

### DIFF
--- a/vscode-trace-common/src/messages/vscode-message-manager.ts
+++ b/vscode-trace-common/src/messages/vscode-message-manager.ts
@@ -1,6 +1,7 @@
 import * as Messages from 'traceviewer-base/lib/message-manager';
 import { OutputAddedSignalPayload } from 'traceviewer-base/lib/signals/output-added-signal-payload';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
+import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
 import JSONBigConfig from 'json-bigint';
 
 const JSONBig = JSONBigConfig({
@@ -47,7 +48,15 @@ export const VSCODE_MESSAGES = {
     REDO: 'redo',
     UPDATE_ZOOM: 'updateZoom',
     OPEN_TRACE: 'openTrace',
-    TRACE_SERVER_STARTED: 'traceServerStarted'
+    TRACE_SERVER_STARTED: 'traceServerStarted',
+    SHOW_MARKER_CATEGORIES: 'showMarkerCategories',
+    SEND_MARKER_SETS: 'sendMarkerSets',
+    GET_MARKER_CATEGORIES: 'getMarkerCategories',
+    GET_MARKER_SETS: 'getMarkerSets',
+    UPDATE_MARKER_CATEGORY_STATE: 'updateMarkerCategoryState',
+    UPDATE_MARKER_SET_STATE: 'updateMarkerSetState',
+    MARKER_SETS_CONTEXT: 'markerSetsContext',
+    MARKER_CATEGORIES_CONTEXT: 'markerCategoriesContext'
 };
 
 export class VsCodeMessageManager extends Messages.MessageManager {
@@ -121,5 +130,25 @@ export class VsCodeMessageManager extends Messages.MessageManager {
 
     saveAsCSV(payload: {traceId: string, data: string}): void {
         vscode.postMessage({command: VSCODE_MESSAGES.SAVE_AS_CSV, payload});
+    }
+
+    fetchMarkerCategories(payload: Map<string, { categoryCount: number, toggleInd: boolean }>): void {
+        const wrapper: string = JSON.stringify([...payload]);
+        vscode.postMessage({command: VSCODE_MESSAGES.SHOW_MARKER_CATEGORIES, data: {wrapper}});
+    }
+
+    fetchMarkerSets(payload: Map<string, { marker: MarkerSet, enabled: boolean }>): void {
+        const wrapper: string = JSON.stringify([...payload]);
+        vscode.postMessage({command: VSCODE_MESSAGES.SEND_MARKER_SETS, data: {wrapper}});
+    }
+
+    setMarkerSetsContext(context: boolean): void {
+        const status: string = JSON.stringify(context);
+        vscode.postMessage({command: VSCODE_MESSAGES.MARKER_SETS_CONTEXT, data: { status }});
+    }
+
+    setMarkerCategoriesContext(context: boolean): void {
+        const status: string = JSON.stringify(context);
+        vscode.postMessage({command: VSCODE_MESSAGES.MARKER_CATEGORIES_CONTEXT, data: { status }});
     }
 }

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -88,6 +88,16 @@
       {
         "command": "serverStatus.stopped",
         "title": "Trace Server: stopped"
+      },
+      {
+        "command": "trace.viewer.toolbar.markersets",
+        "title": "Marker Sets",
+        "icon": "$(three-bars)"
+      },
+      {
+        "command": "trace.viewer.toolbar.filter",
+        "title": "Markers filter",
+        "icon": "$(filter-filled)"
       }
     ],
     "viewsContainers": {
@@ -175,14 +185,24 @@
           "group": "navigation@5"
         },
         {
+          "when": "activeWebviewPanelId == 'react' && traceViewer.markerCategoriesPresent",
+          "command": "trace.viewer.toolbar.filter",
+          "group": "navigation@6"
+        },
+        {
+          "when": "activeWebviewPanelId == 'react' && traceViewer.markerSetsPresent",
+          "command": "trace.viewer.toolbar.markersets",
+          "group": "navigation@7"
+        },
+        {
           "when": "activeWebviewPanelId == 'react'",
           "command": "outputs.openOverview",
-          "group": "navigation@6"
+          "group": "navigation@8"
         },
         {
           "when": "activeWebviewPanelId == 'react'",
           "command": "traceViewer.shortcuts",
-          "group": "navigation@7"
+          "group": "navigation@9"
         }
       ],
       "commandPalette": [

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -9,6 +9,7 @@ import { TraceServerConnectionStatusService } from './utils/trace-server-status'
 import { updateTspClient } from './utils/tspClient';
 import { TraceExtensionLogger } from './utils/trace-extension-logger';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
+import { TraceViewerPanel } from './trace-viewer-panel/trace-viewer-webview-panel';
 
 export let traceLogger: TraceExtensionLogger;
 
@@ -79,6 +80,14 @@ export function activate(context: vscode.ExtensionContext): void {
         zoomHandler(false);
     }));
 
+    context.subscriptions.push(vscode.commands.registerCommand('trace.viewer.toolbar.markersets', () => {
+        TraceViewerPanel.showMarkerSetsOnCurrent();
+    }));
+
+    context.subscriptions.push(vscode.commands.registerCommand('trace.viewer.toolbar.filter', () => {
+        TraceViewerPanel.showMarkersFilterOnCurrent();
+    }));
+
     context.subscriptions.push(vscode.commands.registerCommand('openedTraces.openTraceFolder', () => {
         fileOpenHandler(context, undefined);
     }));
@@ -97,6 +106,9 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('serverStatus.stopped', () => {
         serverStatusService.render(false);
     }));
+
+    vscode.commands.executeCommand('setContext', 'traceViewer.markerSetsPresent', false);
+    vscode.commands.executeCommand('setContext', 'traceViewer.markerCategoriesPresent', false);
 }
 
 export function deactivate(): void {

--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -13,6 +13,7 @@ import 'traceviewer-react-components/style/trace-context-style.css';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { TspClientProvider } from 'vscode-trace-common/lib/client/tsp-client-provider-impl';
+import { MarkerSet } from 'tsp-typescript-client/lib/models/markerset';
 import { VsCodeMessageManager, VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import '../style/trace-viewer.css';
@@ -45,11 +46,8 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
       this._signalHandler.saveAsCSV(payload);
   }
 
-  // TODO add support for marker sets
-  private selectedMarkerCategoriesMap: Map<string, string[]> = new Map<string, string[]>();
-  private selectedMarkerSetId = '';
-
   private _onOverviewSelected = (payload: {traceId: string, outputDescriptor: OutputDescriptor}): void => this.doHandleOverviewSelectedSignal(payload);
+  private onMarkerCategoryClosedSignal = (payload: { traceViewerId: string, markerCategory: string }) => this.doHandleMarkerCategoryClosedSignal(payload);
 
   protected resizeHandlers: (() => void)[] = [];
   protected readonly addResizeHandler = (h: () => void): void => {
@@ -61,6 +59,12 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
           this.resizeHandlers.splice(index, 1);
       }
   };
+
+  private markerCategoriesMap = new Map<string, string[]>();
+  private toolbarMarkerCategoriesMap = new Map<string, { categoryCount: number, toggleInd: boolean }>();
+  private selectedMarkerCategoriesMap = new Map<string, string[]>();
+  private markerSetsMap = new Map<string, { marker: MarkerSet, enabled: boolean }>();
+  private selectedMarkerSetId = '';
 
   constructor(props: {}) {
       super(props);
@@ -78,23 +82,25 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
           const message = event.data; // The JSON data our extension sent
           switch (message.command) {
           case VSCODE_MESSAGES.SET_EXPERIMENT:
-              this.doHandleExperimentSetSignal(convertSignalExperiment(JSONBig.parse(message.data)));
+              this.doHandleExperimentSetSignal(convertSignalExperiment(JSONBig.parse(message.data)), false);
               break;
           case VSCODE_MESSAGES.SET_TSP_CLIENT:
               this.setState({tspClientProvider: new TspClientProvider(message.data, this._signalHandler)}, () => {
                   if (message.experiment) {
-                      this.doHandleExperimentSetSignal(convertSignalExperiment(JSONBig.parse(message.experiment)));
+                      this.doHandleExperimentSetSignal(convertSignalExperiment(JSONBig.parse(message.experiment)), true);
                   }
               });
               break;
           case VSCODE_MESSAGES.ADD_OUTPUT:
               // FIXME: JSONBig.parse() create bigint if numbers are small
               // Not an issue right now for output descriptors.
-              const descriptor = JSONBig.parse(message.data);
-              this.setState({outputs: [...this.state.outputs, descriptor] });
+              if (message?.data) {
+                  const descriptor: OutputDescriptor = JSONBig.parse(message.data);
+                  this.doHandleOutputAddedMessage(descriptor);
+              }
               break;
           case VSCODE_MESSAGES.OPEN_OVERVIEW:
-              this.doHandleExperimentSetSignal(this.state.experiment);
+              this.doHandleExperimentSetSignal(this.state.experiment, false);
               break;
           case VSCODE_MESSAGES.SET_THEME:
               this.doHandleThemeChanged(message.data);
@@ -111,6 +117,26 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
           case VSCODE_MESSAGES.UPDATE_ZOOM:
               this.updateZoom(message.data);
               break;
+          case VSCODE_MESSAGES.UPDATE_MARKER_CATEGORY_STATE:
+              if (message?.data) {
+                  const selection: string[] = JSON.parse(message.data);
+                  this.updateAllMarkerCategoryState(selection);
+              }
+              break;
+          case VSCODE_MESSAGES.UPDATE_MARKER_SET_STATE:
+              if (message?.data) {
+                  this.updateMarkerSetState(message.data);
+              }
+              break;
+          case VSCODE_MESSAGES.GET_MARKER_CATEGORIES:
+              this._signalHandler.fetchMarkerCategories(this.toolbarMarkerCategoriesMap);
+              break;
+          case VSCODE_MESSAGES.GET_MARKER_SETS:
+              this._signalHandler.fetchMarkerSets(this.markerSetsMap);
+              break;
+          case VSCODE_MESSAGES.EXPERIMENT_SELECTED:
+              this.doHandleExperimentSelectedSignal(convertSignalExperiment(JSONBig.parse(message.data)));
+              break;
           }
       });
       window.addEventListener('resize', this.onResize);
@@ -123,12 +149,14 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
       this._signalHandler.notifyReady();
       signalManager().on(Signals.ITEM_PROPERTIES_UPDATED, this._onProperties);
       signalManager().on(Signals.SAVE_AS_CSV, this._onSaveAsCSV);
+      signalManager().on(Signals.MARKER_CATEGORY_CLOSED, this.onMarkerCategoryClosedSignal);
   }
 
   componentWillUnmount(): void {
       signalManager().off(Signals.ITEM_PROPERTIES_UPDATED, this._onProperties);
       signalManager().off(Signals.OVERVIEW_OUTPUT_SELECTED, this._onOverviewSelected);
       signalManager().off(Signals.SAVE_AS_CSV, this._onSaveAsCSV);
+      signalManager().off(Signals.MARKER_CATEGORY_CLOSED, this.onMarkerCategoryClosedSignal);
       window.removeEventListener('resize', this.onResize);
   }
 
@@ -138,6 +166,7 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
 
   private onOutputRemoved(outputId: string) {
       const outputToKeep = this.state.outputs.filter(output => output.id !== outputId);
+      this.removeMarkerCategories(outputId);
       this.setState({outputs: outputToKeep});
   }
 
@@ -161,12 +190,162 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState>  {
       signalManager().fireUpdateZoomSignal(hasZoomedIn);
   }
 
-  protected async doHandleExperimentSetSignal(experiment: Experiment| undefined): Promise<void> {
+  protected async doHandleExperimentSetSignal(experiment: Experiment| undefined, fetchMarkerSets: boolean): Promise<void> {
       if (experiment) {
+          if (fetchMarkerSets) {
+              await this.fetchMarkerSets(experiment.UUID);
+          }
           const defaultOverviewDescriptor: OutputDescriptor | undefined  = await this.getDefaultTraceOverviewOutputDescriptor(experiment);
           this.setState({
               experiment: experiment,
               overviewOutputDescriptor: defaultOverviewDescriptor});
+          this._signalHandler.setMarkerSetsContext(this.markerSetsMap.size > 0);
+          this._signalHandler.setMarkerCategoriesContext(this.toolbarMarkerCategoriesMap.size > 0);
+      }
+  }
+
+  protected doHandleExperimentSelectedSignal(experiment: Experiment| undefined): void {
+      if (experiment?.UUID === this.state.experiment?.UUID) {
+          this._signalHandler.setMarkerSetsContext(this.markerSetsMap.size > 0);
+          this._signalHandler.setMarkerCategoriesContext(this.toolbarMarkerCategoriesMap.size > 0);
+      }
+  }
+
+  protected async doHandleOutputAddedMessage(descriptor: OutputDescriptor): Promise<void> {
+      if (!this.state.outputs.find(output => output.id === descriptor.id)) {
+          await this.fetchAnnotationCategories(descriptor);
+          this.setState({outputs: [...this.state.outputs, descriptor] });
+      }
+  }
+
+  private async fetchMarkerSets(expUUID: string): Promise<void> {
+      if (this.state.tspClientProvider) {
+          const markers = await this.state.tspClientProvider.getTspClient().fetchMarkerSets(expUUID);
+          const markersResponse = markers.getModel();
+          if (markersResponse && markers.isOk()) {
+              const markerSets = markersResponse.model;
+              this.markerSetsMap.clear();
+              if (markerSets.length) {
+                  this.markerSetsMap.set('-1', { marker: { name: 'None', id: '-1' } as MarkerSet, enabled: true });
+              }
+              markerSets.forEach(markerSet => {
+                  if (!this.markerSetsMap.has(markerSet.id)) {
+                      this.markerSetsMap.set(markerSet.id, { marker: markerSet, enabled: false });
+                  }
+              });
+          }
+      }
+  }
+
+  private async fetchAnnotationCategories(output: OutputDescriptor) {
+      if (this.state.experiment && this.state.tspClientProvider) {
+          const annotationCategories = await this.state.tspClientProvider.getTspClient().
+              fetchAnnotationsCategories(this.state.experiment.UUID, output.id, this.selectedMarkerSetId);
+          const annotationCategoriesResponse = annotationCategories.getModel();
+          if (annotationCategories.isOk() && annotationCategoriesResponse) {
+              const markerCategories = annotationCategoriesResponse.model ? annotationCategoriesResponse.model.annotationCategories : [];
+              this.addMarkerCategories(output.id, markerCategories);
+          }
+      }
+  }
+
+  private addMarkerCategories(outputId: string, markerCategories: string[]) {
+      this.removeMarkerCategories(outputId);
+      const selectedMarkerCategories: string[] = [];
+      markerCategories.forEach(category => {
+          const categoryInfo = this.toolbarMarkerCategoriesMap.get(category);
+          const categoryCount = categoryInfo ? categoryInfo.categoryCount + 1 : 1;
+          const toggleInd = categoryInfo ? categoryInfo.toggleInd : true;
+          this.toolbarMarkerCategoriesMap.set(category, { categoryCount, toggleInd });
+          if (toggleInd) {
+              selectedMarkerCategories.push(category);
+          }
+      });
+      this.selectedMarkerCategoriesMap.set(outputId, selectedMarkerCategories);
+      this.markerCategoriesMap.set(outputId, markerCategories);
+      this._signalHandler.setMarkerCategoriesContext(this.toolbarMarkerCategoriesMap.size > 0);
+  }
+
+  private removeMarkerCategories(outputId: string) {
+      const categoriesToRemove = this.markerCategoriesMap.get(outputId);
+      if (categoriesToRemove) {
+          categoriesToRemove.forEach(category => {
+              const categoryInfo = this.toolbarMarkerCategoriesMap.get(category);
+              const categoryCount = categoryInfo ? categoryInfo.categoryCount - 1 : 0;
+              const toggleInd = categoryInfo ? categoryInfo.toggleInd : true;
+              if (categoryCount === 0) {
+                  this.toolbarMarkerCategoriesMap.delete(category);
+              } else {
+                  this.toolbarMarkerCategoriesMap.set(category, { categoryCount, toggleInd });
+              }
+          });
+      }
+      this.markerCategoriesMap.delete(outputId);
+      this.selectedMarkerCategoriesMap.delete(outputId);
+      this._signalHandler.setMarkerCategoriesContext(this.toolbarMarkerCategoriesMap.size > 0);
+  }
+
+  private doHandleMarkerCategoryClosedSignal(payload: { traceViewerId: string, markerCategory: string }) {
+      const traceViewerId = payload.traceViewerId;
+      const markerCategory = payload.markerCategory;
+      if (traceViewerId === this.state.experiment?.UUID) {
+          this.updateMarkerCategoryState(markerCategory, false);
+      }
+  }
+
+  updateMarkerCategoryState(categoryName: string, toggleInd: boolean, skipUpdate?: boolean): void {
+      const toggledmarkerCategory = this.toolbarMarkerCategoriesMap.get(categoryName);
+      if (toggledmarkerCategory) {
+          const categoryCount = toggledmarkerCategory?.categoryCount;
+          this.toolbarMarkerCategoriesMap.set(categoryName, { categoryCount, toggleInd });
+          this.markerCategoriesMap.forEach((categoriesList, outputId) => {
+              const selectedMarkerCategories = categoriesList.filter(category => {
+                  const currCategoryInfo = this.toolbarMarkerCategoriesMap.get(category);
+                  return currCategoryInfo ? currCategoryInfo.toggleInd : false;
+              });
+              this.selectedMarkerCategoriesMap.set(outputId, selectedMarkerCategories);
+          });
+      }
+      if (!skipUpdate) {
+          this.forceUpdate();
+      }
+  }
+
+  updateAllMarkerCategoryState(selection: string[]): void {
+      const set: Set<string> = new Set<string>();
+
+      for (const categoryName of selection) {
+          set.add(categoryName);
+      }
+
+      const markerCategories = this.toolbarMarkerCategoriesMap;
+      for (const [key] of markerCategories) {
+          if (set.has(key)) {
+              this.updateMarkerCategoryState(key, true, true);
+          } else  {
+              this.updateMarkerCategoryState(key, false, true);
+          }
+      }
+      this.forceUpdate();
+  }
+
+  async updateMarkerSetState(markerSetId: string): Promise<void> {
+      if (this.markerSetsMap.get(markerSetId)?.enabled) {
+          return;
+      }
+      this.selectedMarkerSetId = markerSetId;
+      const prevSelectedMarkerSet = Array.from(this.markerSetsMap.values()).find(markerSetItem => markerSetItem.enabled);
+      if (prevSelectedMarkerSet) {
+          prevSelectedMarkerSet.enabled = false;
+      }
+
+      const markerSetEntry = this.markerSetsMap.get(markerSetId);
+      if (markerSetEntry) {
+          this.markerSetsMap.set(markerSetId, { ...markerSetEntry, enabled: true });
+      }
+
+      if (await Promise.all(this.state.outputs.map(output => this.fetchAnnotationCategories(output)))) {
+          this.forceUpdate();
       }
   }
 


### PR DESCRIPTION
- VSCode extensions currently do not support dynamic context menus or submenus: https://github.com/microsoft/vscode/issues/110218
- A recommendation was to use Quick Pick's instead: https://code.visualstudio.com/api/ux-guidelines/quick-picks
- Toolbar buttons have to be statically defined in package.json, making use of `setContext` commands to show/hide the markers toolbar buttons

Fixes #39 