### PR TITLE
Move tsp-client-provider-impl.ts to vscode-trace-common package

### DIFF
--- a/vscode-trace-common/src/client/tsp-client-provider-impl.ts
+++ b/vscode-trace-common/src/client/tsp-client-provider-impl.ts
@@ -3,18 +3,18 @@ import { RestClient, ConnectionStatusListener } from 'tsp-typescript-client/lib/
 import { ExperimentManager } from 'traceviewer-base/lib/experiment-manager';
 import { TraceManager } from 'traceviewer-base/lib/trace-manager';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
-import { VsCodeMessageManager } from 'vscode-trace-common/lib/messages/vscode-message-manager';
+import { VsCodeMessageManager } from '../messages/vscode-message-manager';
 
 export class TspClientProvider implements ITspClientProvider {
 
     private _tspClient: TspClient;
     private _traceManager: TraceManager;
     private _experimentManager: ExperimentManager;
-    private _signalHandler: VsCodeMessageManager;
+    private _signalHandler: VsCodeMessageManager | undefined;
     private _statusListener: ConnectionStatusListener;
     // private _listeners: ((tspClient: TspClient) => void)[];
 
-    constructor(traceServerUrl: string, signalHandler: VsCodeMessageManager
+    constructor(traceServerUrl: string, signalHandler: VsCodeMessageManager | undefined
     ) {
         this._tspClient = new TspClient(traceServerUrl);
         this._traceManager = new TraceManager(this._tspClient);
@@ -22,7 +22,7 @@ export class TspClientProvider implements ITspClientProvider {
 
         this._signalHandler = signalHandler;
         this._statusListener = ((status: boolean) => {
-            this._signalHandler.notifyConnection(status);
+            this._signalHandler?.notifyConnection(status);
         });
         RestClient.addConnectionStatusListener(this._statusListener);
         // this._listeners = [];

--- a/vscode-trace-webviews/src/trace-explorer/available-views/vscode-trace-explorer-views-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/available-views/vscode-trace-explorer-views-widget.tsx
@@ -6,7 +6,7 @@ import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
 import { ReactAvailableViewsWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-views-widget';
 import 'traceviewer-react-components/style/trace-explorer.css';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
-import { TspClientProvider } from '../../common/tsp-client-provider-impl';
+import { TspClientProvider } from 'vscode-trace-common/lib/client/tsp-client-provider-impl';
 import { VsCodeMessageManager, VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import '../../style/react-contextify.css';
 import '../../style/trace-viewer.css';

--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ReactOpenTracesWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-opened-traces-widget';
 import { VsCodeMessageManager, VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { Menu, Item, useContextMenu, ItemParams } from 'react-contexify';
-import { TspClientProvider } from '../../common/tsp-client-provider-impl';
+import { TspClientProvider } from 'vscode-trace-common/lib/client/tsp-client-provider-impl';
 import { ITspClientProvider } from 'traceviewer-base/lib/tsp-client-provider';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';

--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -12,7 +12,7 @@ import { TraceContextComponent } from 'traceviewer-react-components/lib/componen
 import 'traceviewer-react-components/style/trace-context-style.css';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
-import { TspClientProvider } from '../common/tsp-client-provider-impl';
+import { TspClientProvider } from 'vscode-trace-common/lib/client/tsp-client-provider-impl';
 import { VsCodeMessageManager, VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import '../style/trace-viewer.css';


### PR DESCRIPTION
This is to be able to re-use `tsp-client-provider-impl` in the extension package as well.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>