### PR TITLE
Refresh open traces view after trace server started notification

### DIFF
--- a/vscode-trace-common/src/messages/vscode-message-manager.ts
+++ b/vscode-trace-common/src/messages/vscode-message-manager.ts
@@ -46,7 +46,8 @@ export const VSCODE_MESSAGES = {
     UNDO: 'undo',
     REDO: 'redo',
     UPDATE_ZOOM: 'updateZoom',
-    OPEN_TRACE: 'openTrace'
+    OPEN_TRACE: 'openTrace',
+    TRACE_SERVER_STARTED: 'traceServerStarted'
 };
 
 export class VsCodeMessageManager extends Messages.MessageManager {

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -8,6 +8,7 @@ import { fileHandler, openOverviewHandler, resetZoomHandler, undoRedoHandler, zo
 import { TraceServerConnectionStatusService } from './utils/trace-server-status';
 import { updateTspClient } from './utils/tspClient';
 import { TraceExtensionLogger } from './utils/trace-extension-logger';
+import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 
 export let traceLogger: TraceExtensionLogger;
 
@@ -88,6 +89,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(vscode.commands.registerCommand('serverStatus.started', () => {
         serverStatusService.render(true);
+        if (tracesProvider) {
+            tracesProvider.postMessagetoWebview(VSCODE_MESSAGES.TRACE_SERVER_STARTED, undefined);
+        }
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('serverStatus.stopped', () => {

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -136,6 +136,16 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
 	    }, undefined, this._disposables);
 	}
 
+	postMessagetoWebview(_command: string, _data: unknown): void {
+	    if (this._view && _command) {
+	        if (_data) {
+	        	this._view.webview.postMessage({command: _command, data: _data});
+	        } else {
+	            this._view.webview.postMessage({command: _command});
+	        }
+	    }
+	}
+
 	/* eslint-disable max-len */
 	private _getHtmlForWebview(webview: vscode.Webview) {
 	    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.

--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -86,6 +86,10 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
                       this.setState({experimentsOpened: true});
                   }
               }
+              break;
+          case VSCODE_MESSAGES.TRACE_SERVER_STARTED:
+              signalManager().fireTraceServerStartedSignal();
+              this.setState({experimentsOpened: true});
           }
       });
       // this.onOutputRemoved = this.onOutputRemoved.bind(this);


### PR DESCRIPTION
With this the open traces view is populated with the open traces on the server.

Contributes to fixing Issue #15

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

