### PR TITLE
Fix status bar after starting trace server during open trace

### DIFF
--- a/vscode-trace-common/src/client/tsp-client-provider-impl.ts
+++ b/vscode-trace-common/src/client/tsp-client-provider-impl.ts
@@ -25,6 +25,8 @@ export class TspClientProvider implements ITspClientProvider {
             this._signalHandler?.notifyConnection(status);
         });
         RestClient.addConnectionStatusListener(this._statusListener);
+        this._tspClient.checkHealth();
+
         // this._listeners = [];
         // tspUrlProvider.addTraceServerUrlChangedListener(url => {
         //     this._tspClient = new TspClient(url);


### PR DESCRIPTION
Since each webview has it's own RestClient which will update the status bar for the trace server, some webviews might not have the correct status because they haven't sent any TSP messages and the initial state of disconnect is propagated to the status bar. This can lead to an incorrect status bar message for the trace server.

This commit does a health check call to the back-end when the tspclient is created. With this all webviews will have the correct state.

Fixes #160

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>