### PR TITLE
Update experiment when re-opening an existing experiment on the server

### DIFF
--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -132,7 +132,7 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
   }
 
   protected doHandleClickEvent(event: React.MouseEvent<HTMLDivElement>, experiment: Experiment): void {
-      this._signalHandler.reOpenTrace(experiment);
+      this.doHandleReOpenTrace(experiment);
   }
 
   protected doHandleExperimentSelectedSignal(experiment: Experiment | undefined): void {
@@ -171,10 +171,21 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
       this.loading = false;
   }
 
+  protected async doHandleReOpenTrace(experiment: Experiment): Promise<void> {
+      let myExperiment: Experiment | undefined = experiment;
+      if (this.state.tspClientProvider) {
+          const exp = await this.state.tspClientProvider.getExperimentManager().updateExperiment(experiment.UUID);
+          if (exp) {
+              myExperiment = exp;
+          }
+      }
+      this._signalHandler.reOpenTrace(myExperiment);
+  }
+
   protected handleItemClick = (args: ItemParams): void => {
       switch (args.event.currentTarget.id) {
       case 'open-id':
-          this._signalHandler.reOpenTrace(args.props.experiment as Experiment);
+          this.doHandleReOpenTrace(args.props.experiment as Experiment);
           return;
       case 'close-id':
           this._signalHandler.closeTrace(args.props.experiment as Experiment);


### PR DESCRIPTION
Before, when re-opening an experiment right after the trace server started, the Experiment didn't have the start and end time set and the Experiment was still CLOSED.

This patch triggers a fetchExperiment call to open the experiment and to get the current start time and end time.

This patch is needed to fix an issue found with #152.

Fixes #165

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

