### PR TITLE
Use webview.asWebviewUri for generating script paths.

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
@@ -112,6 +112,7 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
 	    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
 	    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'analysisPanel.js'));
 	    const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css'));
+	    const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
 
 	    // Use a nonce to only allow a specific script to be run.
 	    const nonce = getNonce();
@@ -131,7 +132,7 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />
-				<base href="${vscode.Uri.joinPath(this._extensionUri, 'pack').with({ scheme: 'vscode-resource' })}/">
+				<base href="${packUri}/">
 			</head>
 
 			<body>

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -151,6 +151,7 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
 	    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
 	    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'openedTracesPanel.js'));
 	    const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css'));
+	    const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
 
 	    // Use a nonce to only allow a specific script to be run.
 	    const nonce = getNonce();
@@ -170,7 +171,7 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />
-				<base href="${vscode.Uri.joinPath(this._extensionUri, 'pack').with({ scheme: 'vscode-resource' })}/">
+				<base href="${packUri}/">
 			</head>
 
 			<body>

--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -39,6 +39,7 @@ export class TraceExplorerItemPropertiesProvider implements vscode.WebviewViewPr
       // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
       const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'propertiesPanel.js'));
 	  const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css'));
+      const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
 
       // Use a nonce to only allow a specific script to be run.
       const nonce = getNonce();
@@ -58,7 +59,7 @@ export class TraceExplorerItemPropertiesProvider implements vscode.WebviewViewPr
 					connect-src ${getTraceServerUrl()};
                     font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />
-                <base href="${vscode.Uri.joinPath(this._extensionUri, 'pack').with({ scheme: 'vscode-resource' })}/">
+                <base href="${packUri}/">
 			</head>
 
 			<body>

--- a/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
@@ -36,6 +36,7 @@ export class KeyboardShortcutsPanel {
 	private static _getHtmlForWebview(webview: vscode.Webview, extensionUri: vscode.Uri): string {
 	    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
 	    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'pack', 'shortcutsPanel.js'));
+	    const packUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'pack'));
 
 	    // Use a nonce to whitelist which scripts can be run
 	    const nonce = getNonce();
@@ -54,7 +55,7 @@ export class KeyboardShortcutsPanel {
 					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
 					connect-src ${getTraceServerUrl()};
                     font-src ${webview.cspSource}">
-                <base href="${vscode.Uri.joinPath(extensionUri, 'pack').with({ scheme: 'vscode-resource' })}/">
+                <base href="${packUri}/">
 			</head>
 
 			<body>

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -383,6 +383,7 @@ export class TraceViewerPanel {
 	private _getHtmlForWebview() {
 	    const webview = this._panel.webview;
 	    const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css'));
+	    const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
 	    const nonce = getNonce();
 
 	    try {
@@ -403,7 +404,7 @@ export class TraceViewerPanel {
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />
-				<base href="${vscode.Uri.joinPath(this._extensionUri, 'pack').with({ scheme: 'vscode-resource' })}/">
+				<base href="${packUri}/">
 			</head>
 
 			<body>
@@ -416,15 +417,12 @@ export class TraceViewerPanel {
 
 	/* eslint-disable max-len */
 	private _getReactHtmlForWebview(): string {
-	    // eslint-disable-next-line @typescript-eslint/no-var-requires
-	    const scriptPathOnDisk = vscode.Uri.joinPath(this._extensionUri, 'pack', 'trace_panel.js');
-	    const scriptUri = scriptPathOnDisk.with({ scheme: 'vscode-resource' });
-	    // const stylePathOnDisk = vscode.Uri.file(path.join(this._extensionPath, 'build', mainStyle));
-	    // const styleUri = stylePathOnDisk.with({ scheme: 'vscode-resource' });
 
 	    // Fetching codicons styles
 	    const webview = this._panel.webview;
+	    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'trace_panel.js'));
 	    const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css'));
+	    const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
 
 	    // Use a nonce to whitelist which scripts can be run
 	    const nonce = getNonce();
@@ -444,7 +442,7 @@ export class TraceViewerPanel {
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />
-				<base href="${vscode.Uri.joinPath(this._extensionUri, 'pack').with({ scheme: 'vscode-resource' })}/">
+				<base href="${packUri}/">
 			</head>
 
 			<body>


### PR DESCRIPTION
Makes all URI builders utilize webview.asWebviewUri method.  This ensures that the files can be served to remote clients.

Signed-off-by: Will Yang <william.yang@ericsson.com>