### PR TITLE
Add pack dir to .vscodeignore  file

### DIFF
--- a/vscode-trace-extension/.vscodeignore
+++ b/vscode-trace-extension/.vscodeignore
@@ -4,4 +4,5 @@ tsconfig.json
 webpack.config.js
 *.tsbuildinfo
 .eslintrc.js
+pack
 src


### PR DESCRIPTION
Removes the pack directory from the extension build process.

Signed-off-by: Will Yang <william.yang@ericsson.com>