### PR TITLE
Correct SHA in .git-blame-ignore after prettier PR merge

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Code formatted w Prettier
-e16c0c01dc0366ca57693c2d9fe00cb8834dbc8b
+d9243b91aa114f37964a387f063c29f2c4c64fda


### PR DESCRIPTION
SHA of PR #176 is different than the actual SHA after the merge operation.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>

