### PR TITLE
Fix path failure preventing trace from opening

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { getTspClientUrl, getTraceServerUrl } from '../utils/tspClient';
 import { TraceServerConnectionStatusService } from '../utils/trace-server-status';
@@ -115,7 +116,7 @@ export class TraceViewerPanel {
     private static async saveTraceCsv(csvData: string, defaultFileName: string) {
         const saveDialogOptions = {
             defaultUri: vscode.workspace.workspaceFolders
-                ? vscode.Uri.file(vscode.workspace.workspaceFolders[0].uri.path + '/' + defaultFileName)
+                ? vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, defaultFileName))
                 : undefined,
             saveLabel: 'Save as CSV',
             filters: {


### PR DESCRIPTION
When doing some testing on an internal extension, I noticed that we could no longer use the Open With TraceViewer command on Windows due to an invalid path failing (worked on Linux). 

I was able to trace the cause of this it to some code that uses .path instead of .fsPath, which is intended for use with the filesystem and scrubs out improper path values  (which is what caused our error!) I also fixed this in other areas of the code.

This fixes a critical issue which prevents users from opening traces in some cases.