### PR TITLE
Use trace server manager with Open Trace command

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/trace-tree.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-tree.ts
@@ -127,7 +127,7 @@ export const zoomHandler = (hasZoomedIn: boolean): void => {
     TraceViewerPanel.zoomOnCurrent(hasZoomedIn);
 };
 
-const openDialog = async (): Promise<vscode.Uri | undefined> => {
+export const openDialog = async (): Promise<vscode.Uri | undefined> => {
     const props: vscode.OpenDialogOptions = {
         title: 'Open Trace',
         canSelectFolders: true,
@@ -144,15 +144,7 @@ const openDialog = async (): Promise<vscode.Uri | undefined> => {
 
 export const fileHandler =
     (analysisTree: AnalysisProvider) =>
-    async (context: vscode.ExtensionContext, traceUri: vscode.Uri | undefined): Promise<void> => {
-        // We need to resolve trace URI before starting the progress dialog because we rely on trace URI for dialog title
-        if (!traceUri) {
-            traceUri = await openDialog();
-            if (!traceUri) {
-                return;
-            }
-        }
-
+    async (context: vscode.ExtensionContext, traceUri: vscode.Uri): Promise<void> => {
         const resolvedTraceURI: vscode.Uri = traceUri;
         vscode.window.withProgress(
             {


### PR DESCRIPTION
When the command 'openTraceFolder' is invoked from the Open Trace button, change the order so that the user is first prompted to select a trace folder. In order to do this, the openDialog() method is exported and is no longer called from the fileOpenHandler() method.

Use the selected trace to start the trace server using the trace server manager, which will select the proper contributor to start the server, based on the trace path.

Remove the execution of 'start-if-stopped' command from the startTraceServerIfAvailable() method, and make its pathToTrace parameter mandatory.

The fileOpenHandler() method is called last, and its traceUri parameter is now mandatory.

Fixes #183.