### PR TITLE
Fix 'yarn watch' Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ ln -s <vscode-trace-extension root>/vscode-trace-extension-x.x.x.vsix ./
 
 ## Developing the extension
 
-When having to modify the code of the extension (in the `vscode-trace-extension` folder), one can simply run the `yarn` command. It is also possible to watch for changes to have no manual steps to do before re-running the extension: `yarn watch` or `ctrl-shift-b` and select the task `npm: watch - vscode-trace-extension`.
-
-For changes in the webview part (in the `vscode-trace-webviews` folder), you can run the `yarn` command, simply re-opening a trace should show the changes. It is also possible to watch for changes with `yarn watch` or `ctrl-shift-b` and selecting the task `npm: watch - vscode-trace-webviews`.
+From the root directory execute `yarn run watch`.  This will watch and bundle `vscode-trace-common`, `vscode-trace-extension`, and `vscode-trace-webviews`.  All outputs will be in one terminal.  Changes can be observed and tested in the `Extension Development Host` by pressing `F5`.
 
 For more information about `VsCode WebView API` see [here][vscode-webview].
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "prepare": "lerna run prepare",
-    "watch": "lerna run watch",
+    "watch": "lerna exec --stream --parallel -- \"yarn run watch\"",
     "clean": "lerna run clean",
     "vsce:package": "lerna run vsce:package",
     "lint": "lerna run lint",

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -300,7 +300,8 @@
     "vscode:prepublish": "yarn prepare && yarn run webpack:production",
     "vsce:package": "vsce package --yarn",
     "vsce:ls": "vsce ls --yarn",
-    "watch": "tsc -w -p tsconfig.json",
+    "tswatch": "tsc -w -p tsconfig.json",
+    "watch": "yarn run webpack-dev",
     "lint": "eslint .",
     "format:write": "prettier --write ./src",
     "format:check": "prettier --check ./src"


### PR DESCRIPTION
## Fix 'Yarn Watch' Script

Yarn watch script in root now executes 'yarn run watch' in each subdirectory and all outputs are streamed to a single terminal.
Tested to ensure that the changes in each directory are shown in Extension Development Host (webviews, extension, common) with the script.
README updated to reflect changes.

Developer QOL improvement.

Signed-off-by: Will Yang <william.yang@ericsson.com>