### PR TITLE
Trigger first release to open-vsx.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             - uses: actions/checkout@v3
               with:
                 fetch-depth: 0
-            - uses: pipe-cd/actions-gh-release@v2.3.4
+            - uses: pipe-cd/actions-gh-release@v2.6.0
               with:
                 release_file: 'RELEASE'
                 token: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE
+++ b/RELEASE
@@ -1,1 +1,8 @@
-tag: v0.0.0
+tag: v0.2.0
+
+commitInclude:
+  parentOfMergeCommit: true
+
+releaseNoteGenerator:
+  showAbbrevHash: true
+  showCommitter: false

--- a/doc/Publishing.md
+++ b/doc/Publishing.md
@@ -5,12 +5,12 @@ The Github workflows are setup to make this relatively simple.
 When it's desired to have a new release:
 
 - open a Pull Request that steps the version of the extension in `vscode-trace-extension/package.json`
-- As part of the PR, update file RELEASE \[1\] in the repo root. Add or modify it to reflect the new version-to-be-released.
+- As part of the PR, update file RELEASE \[1\] in the repo root. Update the tag to match the one in package.json.
   e.g.
-  > tag: v0.1.0                        # The tag number will be created. Required.
+  > tag: v0.2.1
 
-- The PR should be automatically updated, and automatically generated release noted added to it
-- Upon merging the PR, the GH release will automatically be created, and the release notes added to document it. A release tag, for the new relase will also be created in the repo.
-- The release tag should trigger a publish workflow that will build and release a new version of the extension to openvsx.org
+- The PR should be automatically updated, and a preview of the automatically generated release noted, will be added in the form of a comment
+- Upon merging the PR, the GH release will automatically be created, using the generated release notes. A git tag for the new release will also be created in the repo. If needed, a committer can edit to release. 
+- The creation of the release git tag should trigger a publish workflow that will build and release a new version of the extension to openvsx.org
 
 \[1\]: Here is the action that we use. For more details see its documentation: https://github.com/pipe-cd/actions-gh-release#actions-gh-release

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:server": "./trace-compass-server/tracecompass-server",
     "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/dorsal-lab/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz",
     "download:openvscode-server": "mkdir -p test-resources; cd test-resources; curl -L -o openvscode-server-v1.77.3-linux-x64.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.77.3/openvscode-server-v1.77.3-linux-x64.tar.gz; tar -xf openvscode-server-v1.77.3-linux-x64.tar.gz",
-    "configure:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; sed -i 's;\"$@\".*$;\"$@\" --without-connection-token --install-extension $ROOT/../../vscode-trace-extension/vscode-trace-extension-0.1.0.vsix --default-folder=$ROOT/../../TraceCompassTutorialTraces --start-server;g' openvscode-server",
+    "configure:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; sed -i 's;\"$@\".*$;\"$@\" --without-connection-token --install-extension $ROOT/../../vscode-trace-extension/vscode-trace-extension-*.vsix --default-folder=$ROOT/../../TraceCompassTutorialTraces --start-server;g' openvscode-server",
     "start:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; ./openvscode-server ${0}",
     "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
     "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review"

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-trace-extension",
   "displayName": "Trace Viewer for VSCode",
   "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "engines": {
     "vscode": "^1.52.0"


### PR DESCRIPTION
This is the first try, so we may need to adjust some things to make it work in the end.

The idea is to update file `RELEASE`, adding a new release tag in there. Then we expect that tentative, automatically-generated release notes, will be added to this PR, for our review. Once we merge the PR, a GitHub release v0.2.0 should be created automatically in the repo, with attached release notes. The tag's creation should then trigger the job that published the extension to open-vsx.org.

Note: I picked v0.2.0 to avoid conflicting with the "vscode trace extension", that's already released on the Visual Studio Marketplace (which is currently at v0.1.44). I propose we go with a v1.0.0 version after discussions with other contributors, and after our release/publish infrastructure has been demonstrated to work well.

See [below](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pull/194#issuecomment-1920084882) for the automatically generated release notes we are currently obtaining. I played-around with the [options](https://github.com/pipe-cd/actions-gh-release/tree/v2.3.4/#usage) quite a bit and something about them is flaky - it could be due to the slightly strange initial run we have, going-back a long while in history, for this first run. In any case, the generation does not need to be perfect -any committer can edit them after the fact, from the GitHub release page. 

I think it might be a bit controversial to have both commits and PRs documented in there - I personally like the idea of having one page where we can quickly find both, but I suggest we adjust the options after merging this PR, at the next release - I hope it will work better then. 