### PR TITLE
Correct extension's stated license

### DIFF
--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Trace Viewer for VSCode",
   "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
   "version": "0.1.0",
-  "license": "EPL-2.0",
+  "license": "MIT",
   "engines": {
     "vscode": "^1.52.0"
   },


### PR DESCRIPTION
The wrong license had been added by mistake - use the correct one: MIT.