### PR TITLE
Add bogus release tag in file RELEASE

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,1 +1,1 @@
-# Release file - see documentation: https://github.com/pipe-cd/actions-gh-release#usage
+tag: v0.0.0


### PR DESCRIPTION
That seems to be necessary for action "actions-gh-release" to work correctly for the first time.

Else we get the following error:

> 2024/01/30 22:49:25 Start running actions-gh-release 2024/01/30 22:49:25 Successfully parsed arguments
2024/01/30 22:49:25 Successfully parsed GitHub event pull_request
	base-commit 939e8c2709300d010087478703073820c30bb509
	head-commit 3e205211bf0b0401b7d8669a0e175517cc94bf13
2024/01/30 22:49:25 Failed to build release for RELEASE: tag must be specified

Note: the `GitHub release` job is still expected to fail in this PR - it should make it possible for #194 to succeed, once this here is merged and #194 is rebased.