### PR TITLE
[CI] Trigger publish job on tag creation, try again to publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,10 +3,10 @@ name: CI/CD
 on:
   push:
     branches: [ master ]
-    tags:
-      - 'v*'
   pull_request:
     branches: [ master ]
+  # branch or tag created  
+  create:
 
 jobs:
 

--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.0
+tag: v0.2.1
 
 commitInclude:
   parentOfMergeCommit: true


### PR DESCRIPTION
When we previously created the v0.2.0 release using the RELEASE file, the corresponding GitHub release and git tag were created. However the publish job was not triggered. Testing on my fork, I concluded that the workflow needs to trigger on "create" tag, not on "push". One commit in this PR fixes this.

A slight side-effect of triggering the ci-cd workflow on "create" events is that it will now run also on branch creation. So it may run a bit more often than before. I think this is preferable for now, vs having complex "if:" conditions on each job in the workflow. 

Also, in a separate commit, we step the tag in file RELEASE to v0.2.1 to trigger a new release, which this time will hopefully trigger the publish job and successfully publish the extension to open-vsx. Afterwards,  I plan to delete the (failed)  v0.2.0 release, after copying its generated release notes to the new release
