### PR TITLE
Use GitHub token from a committer in gh-release job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,8 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  # branch or tag created  
-  create:
+  release:
+    types:
+      - published
 
 jobs:
 
@@ -93,7 +94,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: [16]
     # Only execute when the trigger was a tag (new release)
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,13 @@ jobs:
             - uses: pipe-cd/actions-gh-release@v2.6.0
               with:
                 release_file: 'RELEASE'
-                token: ${{ secrets.GITHUB_TOKEN }}
+                # Actions that run using the auto-generated GitHub token are
+                # not allowed to trigger a new workflow run. In this case we want
+                # the tag created by actions-gh-release to trigger the main workflow
+                # and result in publishing the extension to open-vsx.
+                # The following scopes are required when creating the committer token:
+                #  - repo:status, repo_deployment, public_repo, read:org
+                # See here for more details:
+                # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+                token: ${{ secrets.GH_COMMITTER_TOKEN }}
               


### PR DESCRIPTION
It turns-out that using the GitHub token, that's automatically generated for each workflow run, does not allow for further workflow(s) being triggered. We were relying on that feature, for the "publish" job to trigger, after action "actions-gh-release" creates a git tag in the repo.
    
Instead, for that to work, we need to use an alternate token, from a committer. I will set such a token in the repo as a secret, under name "GH_COMMITTER_TOKEN"

Also a couple of minor upadates to the `ci-cd` workslow:
- use 'release' as workflow trigger to start publish job
- check before running job that the workflow was triggered by a release tag 'reference". These map to, e.g.: 

  github.event_name:  release
  github.ref:  refs/tags/v0.2.2