### PR TITLE
[CI] Infrastructure to enable publish to Marketplace 

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -84,8 +84,9 @@ jobs:
     - name: Run format check
       run: yarn format:check
 
-  publish:
-    name: Publish extension to openvsx.org
+  publish-oxsv:
+    # https://open-vsx.org/
+    name: Publish extension to public Open VSX Registry
     runs-on: ${{ matrix.os }}
     needs:
       - build-test
@@ -115,3 +116,36 @@ jobs:
           # have ovsx consume the PAT from environment - if it's not handled explicitly 
           # in the workflow, less risk to leak it
           OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+
+  publish-vs-marketplace:
+    # https://marketplace.visualstudio.com/
+    name: Publish extension to Visual Studio Marketplace
+    runs-on: ${{ matrix.os }}
+    needs:
+      - build-test
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16]
+    # Only execute when the trigger was a tag (new release)
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v4
+        with:
+          name: extension
+          path: vscode-trace-extension
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn --frozen-lockfile --ignore-scripts
+      - name: Publish extension
+        run: |
+          ls -al  vscode-trace-extension/*.vsix
+          npx vsce publish -i vscode-trace-extension/*.vsix --skip-duplicate
+        env:
+          # have vsce consume the PAT from environment - if it's not handled explicitly 
+          # in the workflow, less risk to leak it
+          VSCE_PAT: ${{ secrets.VS_MARKETPLACE_TOKEN }}


### PR DESCRIPTION
Add a job to publish the extension to the Visual Studio Marketplace, using the PAT setup for us by webmaster at org level.

This PR will not, by itself, trigger a publish to the Marketplace. Rather, the new job will trigger along with the existing job that publishes to the public open-vsx registry, when an eventual PR is merged, that modifies the `RELEASE` root file, adding a new release tag in there.

Note: Since the [Trace Server extension](https://github.com/eclipse-cdt-cloud/vscode-trace-server), depends on this extension here, we should be careful to publish this (Viewer) extension first to the Marketplace. 