### PR TITLE
Release v0.2.3

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.2
+tag: v0.2.3
 
 commitInclude:
   parentOfMergeCommit: true

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-trace-extension",
   "displayName": "Trace Viewer for VSCode",
   "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "license": "MIT",
   "engines": {
     "vscode": "^1.52.0"


### PR DESCRIPTION
Trigger release v0.2.3. If everything goes well, this time the extension should be published to the Visual Studio Markerplace, in addition to public OpenVSX (open-vsx.org).