### PR TITLE
[TENTATIVE - DO NOT MERGE][Breaking] Rename extension to: eclipse-cdt…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VSCode Trace Extension
+# VSCode Trace Viewer Extension
 
 This document contains information that may be useful for developers that want to build, modify, enhance and/or debug this extension. If you only intend to consume the extension, it might be easier to get it from the [public OpenVSX registry](https://www.open-vsx.org/extension/eclipse-cdt/vscode-trace-extension),
 
@@ -232,7 +232,7 @@ onWebviewPanelCreated(listener: (data: vscode.WebviewPanel) => void): void
 
 ```javascript
 //The following retrieves the API object from the vscode-trace-extension
-const ext = vscode.extensions.getExtension("eclipse-cdt.vscode-trace-extension");
+const ext = vscode.extensions.getExtension("eclipse-cdt.vscode-trace-viewer");
 const importedApi = ext.exports;
 ```
 

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-trace-extension",
+  "name": "vscode-trace-viewer",
   "displayName": "Trace Viewer for VSCode",
   "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
   "version": "0.2.3",


### PR DESCRIPTION
….vscode-trace-viewer

Note: this is tentative for now - we will attempt to publish to the Marketplace without changing the name at first.

From 'vscode-trace-extension'. This affects the extension's name, used to publish it. The internal name, e.g. used in the repo's folder name keep the original name.

This name change is necessary so we can publish the extension to the Visual Studio Marketplace, which now requires that extensions published there have a unique name, irrespective of publisher/namespace.

Note: this is a breaking change since other extensions that use the API offered by this one will need to get a reference, using the vscode extensions API, using the new name to look it up.

For example, companion extension "eclipse-cdt.vscode-trace-server", which does that, will need to use the new name.

 Follow-up: will need to adjust any reference from companion extension vscode-trace-viewer, that uses the API. See tentative PR:
https://github.com/eclipse-cdt-cloud/vscode-trace-server/pull/31