### PR TITLE
[license] Get rid of version of 3PP version that's deprecated and fails the license check

### DIFF
--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -259,7 +259,7 @@
     ]
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.17",
+    "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@vscode/codicons": "^0.0.33",

--- a/vscode-trace-webviews/package.json
+++ b/vscode-trace-webviews/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/",
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.17",
+    "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,18 +238,6 @@
   resolved "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
   integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
 
-"@fortawesome/fontawesome-common-types@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
-  integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==
-
-"@fortawesome/fontawesome-svg-core@^1.2.17":
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.3.0.tgz#343fac91fa87daa630d26420bfedfba560f85885"
-  integrity sha512-UIL6crBWhjTNQcONt96ExjUnKt1D68foe3xjEensLDclqQ6YagwCRYVQdrp/hW0ALRp/5Fv/VKw+MqTUWYYvPg==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.3.0"
-
 "@fortawesome/fontawesome-svg-core@^1.2.17 <1.3.0":
   version "1.2.36"
   resolved "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"


### PR DESCRIPTION
The following 3PP dependency version, used in this repo and that currently fails the license check, has been deprecated:

`@fortawesome/fontawesome-common-types@0.3.0`

Eclipse Foundation ticket about its license:

https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/12947

In theia-trace-extension, we had previously constrained the version range of the related dependency that pulls it, forcing a non-deprecated version to be used:

https://github.com/eclipse-cdt-cloud/theia-trace-extension/commit/e44236a292b3125e95454944c1ed8199e0692f52

I think we should do the same here.