### PR TITLE
Improvements for accurate display of 'Welcome View' 

### DIFF
--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -90,6 +90,11 @@
         "icon": "$(new-folder)"
       },
       {
+        "command": "trace-explorer.refreshContext",
+        "title": "Refresh Trace Explorer",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "traceViewer.shortcuts",
         "title": "Trace Viewer Keyboard and Mouse Shortcuts",
         "icon": "$(info)"
@@ -175,6 +180,11 @@
         {
           "command": "openedTraces.openTraceFolder",
           "when": "view == traceExplorer.openedTracesView && !trace-explorer.noExperiments",
+          "group": "navigation"
+        },
+        {
+          "command": "trace-explorer.refreshContext",
+          "when": "view == welcome || view == traceExplorer.openedTracesView",
           "group": "navigation"
         }
       ],

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -125,42 +125,49 @@
     "views": {
       "trace-explorer": [
         {
+          "type": "tree",
+          "name": "Welcome",
+          "id": "welcome",
+          "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
+        },
+        {
           "type": "webview",
           "id": "traceExplorer.openedTracesView",
-          "name": "Opened Traces"
+          "name": "Opened Traces",
+          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
         },
         {
           "type": "webview",
           "id": "traceExplorer.availableViews",
           "name": "Views",
-          "when": "!trace-explorer.noExperiments"
+          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
         },
         {
           "type": "webview",
           "id": "traceExplorer.timeRangeDataView",
           "name": "Time Range Data",
-          "when": "!trace-explorer.noExperiments"
+          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
         },
         {
           "type": "webview",
           "id": "traceExplorer.itemPropertiesView",
           "name": "Item Properties",
-          "when": "!trace-explorer.noExperiments"
+          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
         }
       ]
     },
     "viewsWelcome": [
       {
-        "view": "traces",
-        "contents": "No traces found [learn more](https://www.eclipse.org/tracecompass/).\n[Add traces](command:nodeDependencies.addEntry)"
+        "view": "welcome",
+        "name": "Open Trace",
+        "contents": "There are currently no opened traces. \n[Open Trace](command:openedTraces.openTraceFolder)",
+        "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
       },
       {
-        "view": "views",
-        "contents": "No trace selected [learn more](https://www.eclipse.org/tracecompass/)"
-      },
-      {
-        "view": "item properties",
-        "contents": "No properties to show"
+        "view": "welcome",
+        "name": "Documentation",
+        "contents": "To learn more about how to use the Trace Viewer [read our documentation](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/vscode-trace-extension/README.md).",
+        "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
       }
     ],
     "menus": {

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -15,7 +15,12 @@ import {
     keyboardShortcutsHandler
 } from './trace-explorer/trace-tree';
 import { TraceServerConnectionStatusService } from './utils/trace-server-status';
-import { getTspClientUrl, updateTspClientUrl, isTraceServerUp } from './utils/backend-tsp-client-provider';
+import {
+    getTspClientUrl,
+    updateTspClientUrl,
+    isTraceServerUp,
+    updateNoExperimentsContext
+} from './utils/backend-tsp-client-provider';
 import { TraceExtensionLogger } from './utils/trace-extension-logger';
 import { ExternalAPI, traceExtensionAPI } from './external-api/external-api';
 import { TraceExtensionWebviewManager } from './utils/trace-extension-webview-manager';
@@ -190,9 +195,20 @@ export function activate(context: vscode.ExtensionContext): ExternalAPI {
         })
     );
 
+    context.subscriptions.push(
+        vscode.commands.registerCommand('trace-explorer.refreshContext', async () => {
+            const isUp = await isTraceServerUp();
+            vscode.commands.executeCommand('setContext', 'traceViewer.serverUp', isUp);
+            if (isUp) {
+                await updateNoExperimentsContext();
+            }
+        })
+    );
+
     vscode.commands.executeCommand('setContext', 'traceViewer.markerSetsPresent', false);
     vscode.commands.executeCommand('setContext', 'traceViewer.markerCategoriesPresent', false);
     vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', true);
+    vscode.commands.executeCommand('trace-explorer.refreshContext');
     serverStatusService.checkAndUpdateServerStatus();
     return traceExtensionAPI;
 }

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -74,6 +74,7 @@ export function activate(context: vscode.ExtensionContext): ExternalAPI {
             await startTraceServerIfAvailable(file.fsPath);
             if (await isTraceServerUp()) {
                 fileOpenHandler(context, file);
+                vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', false);
             }
         })
     );
@@ -163,6 +164,7 @@ export function activate(context: vscode.ExtensionContext): ExternalAPI {
             await startTraceServerIfAvailable(traceUri.fsPath);
             if (await isTraceServerUp()) {
                 fileOpenHandler(context, traceUri);
+                vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', false);
             }
         })
     );
@@ -190,6 +192,7 @@ export function activate(context: vscode.ExtensionContext): ExternalAPI {
 
     vscode.commands.executeCommand('setContext', 'traceViewer.markerSetsPresent', false);
     vscode.commands.executeCommand('setContext', 'traceViewer.markerCategoriesPresent', false);
+    vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', true);
     serverStatusService.checkAndUpdateServerStatus();
     return traceExtensionAPI;
 }

--- a/vscode-trace-extension/src/test/extension-test.spec.ts
+++ b/vscode-trace-extension/src/test/extension-test.spec.ts
@@ -16,7 +16,7 @@ test('Open Trace from Explorer', async ({ page }) => {
 
 test('Open Trace from Trace Viewer', async ({ page }) => {
     await page.getByRole('tab', { name: 'Trace Viewer' }).locator('a').click();
-    await page.getByRole('button', { name: 'Opened Traces Section' }).hover();
+    await page.getByRole('button', { name: 'Open Trace' }).hover();
     await page.getByRole('button', { name: 'Open Trace' }).click();
     await page.getByRole('option', { name: '202-bug-hunt' }).locator('a').click();
     await page.getByRole('option', { name: 'cat-kernel' }).locator('a').click();

--- a/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
@@ -63,8 +63,7 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
                 switch (message.command) {
                     case VSCODE_MESSAGES.CONNECTION_STATUS:
                         if (message.data && message.data.status) {
-                            const status: boolean = JSON.parse(message.data.status);
-                            this._statusService.render(status);
+                            this._statusService.checkAndUpdateServerStatus();
                         }
                         return;
                     case VSCODE_MESSAGES.WEBVIEW_READY:

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -5,7 +5,11 @@ import * as vscode from 'vscode';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import { TraceViewerPanel } from '../../trace-viewer-panel/trace-viewer-webview-panel';
 import { TraceServerConnectionStatusService } from '../../utils/trace-server-status';
-import { getTraceServerUrl, getTspClientUrl } from '../../utils/backend-tsp-client-provider';
+import {
+    getTraceServerUrl,
+    getTspClientUrl,
+    updateNoExperimentsContext
+} from '../../utils/backend-tsp-client-provider';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { traceExtensionWebviewManager } from 'vscode-trace-extension/src/extension';
 
@@ -123,11 +127,7 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
                         }
                         return;
                     case VSCODE_MESSAGES.OPENED_TRACES_UPDATED:
-                        if (message.numberOfOpenedTraces > 0) {
-                            vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', false);
-                        } else if (message.numberOfOpenedTraces === 0) {
-                            vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', true);
-                        }
+                        updateNoExperimentsContext();
                         return;
                     case VSCODE_MESSAGES.OPEN_TRACE:
                         vscode.commands.executeCommand('openedTraces.openTraceFolder');

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -86,8 +86,7 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
                 switch (message.command) {
                     case VSCODE_MESSAGES.CONNECTION_STATUS:
                         if (message.data && message.data.status) {
-                            const status: boolean = JSON.parse(message.data.status);
-                            this._statusService.render(status);
+                            this._statusService.checkAndUpdateServerStatus();
                         }
                         return;
                     case VSCODE_MESSAGES.WEBVIEW_READY:

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -255,8 +255,7 @@ export class TraceViewerPanel {
                         return;
                     case VSCODE_MESSAGES.CONNECTION_STATUS:
                         if (message.data?.status && this._statusService) {
-                            const status: boolean = JSON.parse(message.data.status);
-                            this._statusService.render(status);
+                            this._statusService.checkAndUpdateServerStatus();
                         }
                         return;
                     case VSCODE_MESSAGES.SHOW_MARKER_CATEGORIES:

--- a/vscode-trace-extension/src/utils/backend-tsp-client-provider.ts
+++ b/vscode-trace-extension/src/utils/backend-tsp-client-provider.ts
@@ -36,12 +36,15 @@ export const addTspClientChangeListener = (listenerFunction: (tspClient: TspClie
 
 /**
  * Get the status of the server.
+ * Updates the VSCode Context for `traceViewer.serverUp`
  * @returns server status as boolean
  */
-export async function isUp(): Promise<boolean> {
+export async function isTraceServerUp(): Promise<boolean> {
     const health = await getTspClient().checkHealth();
     const status = health.getModel()?.status;
-    return health.isOk() && status === 'UP';
+    const serverIsUp = health.isOk() && status === 'UP';
+    vscode.commands.executeCommand('setContext', 'traceViewer.serverUp', serverIsUp);
+    return serverIsUp;
 }
 
 function getUriRootFromUserSettings(): string {

--- a/vscode-trace-extension/src/utils/backend-tsp-client-provider.ts
+++ b/vscode-trace-extension/src/utils/backend-tsp-client-provider.ts
@@ -47,6 +47,19 @@ export async function isTraceServerUp(): Promise<boolean> {
     return serverIsUp;
 }
 
+/**
+ * Checks for opened traces and updates the vscode context `trace-explorer.noExperiments`
+ */
+export async function updateNoExperimentsContext(): Promise<void> {
+    const response = await getTspClient().fetchExperiments();
+    if (!response.isOk()) {
+        return;
+    }
+    const noExperiments = !response.getModel()?.length;
+    vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', noExperiments);
+    return;
+}
+
 function getUriRootFromUserSettings(): string {
     const tsConfig = vscode.workspace.getConfiguration('trace-compass.traceserver');
     const traceServerUrl: string = tsConfig.get<string>('url') || 'http://localhost:8080';

--- a/vscode-trace-extension/src/utils/trace-server-status.ts
+++ b/vscode-trace-extension/src/utils/trace-server-status.ts
@@ -10,7 +10,8 @@ export class TraceServerConnectionStatusService {
     }
 
     public checkAndUpdateServerStatus = async (): Promise<void> => {
-        this.render(await isTraceServerUp());
+        const isUp = await isTraceServerUp();
+        this.render(isUp);
     };
 
     private render = (status: boolean): void => {

--- a/vscode-trace-extension/src/utils/trace-server-status.ts
+++ b/vscode-trace-extension/src/utils/trace-server-status.ts
@@ -1,4 +1,5 @@
-import { StatusBarItem, ThemeColor } from 'vscode';
+import { ThemeColor, StatusBarItem } from 'vscode';
+import { isTraceServerUp } from './backend-tsp-client-provider';
 
 export class TraceServerConnectionStatusService {
     private statusBarItem: StatusBarItem;
@@ -8,7 +9,11 @@ export class TraceServerConnectionStatusService {
         this.statusBarItem.hide();
     }
 
-    public async render(status: boolean): Promise<void> {
+    public checkAndUpdateServerStatus = async (): Promise<void> => {
+        this.render(await isTraceServerUp());
+    };
+
+    private render = (status: boolean): void => {
         if (status) {
             this.statusBarItem.backgroundColor = new ThemeColor('statusBarItem.warningBackground');
             this.statusBarItem.text = '$(check) Trace Server';
@@ -19,5 +24,5 @@ export class TraceServerConnectionStatusService {
             this.statusBarItem.tooltip = 'Trace Viewer: server not found';
         }
         this.statusBarItem.show();
-    }
+    };
 }

--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -102,7 +102,12 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
         signalManager().off(Signals.OPENED_TRACES_UPDATED, this.onUpdateSignal);
     }
 
+    private initialized = false;
     protected doHandleOpenedTracesChanged(payload: OpenedTracesUpdatedSignalPayload): void {
+        if (!this.initialized) {
+            this.initialized = true;
+            return;
+        }
         this._signalHandler.updateOpenedTraces(payload.getNumberOfOpenedTraces());
     }
 


### PR DESCRIPTION
Adds `traceViewer.serverOn` VSCode context.

Replaces the use of `ReactPlaceholderWidget` with a welcome view.

Improves tracking of `trace-explorer.noExperiments` VSCode Context.

![image](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/assets/98342456/dc5fdaab-556a-432c-bb58-bbfc809ce142)

Signed-off-by: Will Yang <william.yang@ericsson.com>