### PR TITLE
Handling of Files with Open Trace Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ onWebviewPanelCreated(listener: (data: vscode.WebviewPanel) => void): void
 onSignalManagerSignal(event: string | symbol, listener: (...args: unknown[]) => void): void;
 offSignalManagerSignal(event: string | symbol, listener: (...args: unknown[]) => void): void;
 addTraceServerContributor(contributor: TraceServerContributor): void;
+setHandleTraceResourceType(handleFiles: boolean, handleFolders: boolean): void;
 ```
 
 ### Using the API from Adopter Extensions
@@ -336,4 +337,14 @@ const contributor: TraceServerContributor = {
   };
 
 importedApi.addTraceServerContributor(contributor);
+```
+
+If adopter extensions want to customize the type of trace resources (File and/or Folder) that the base extension should handle, it can be set by calling `setHandleTraceResourceType`.
+
+```javascript
+const handleTraceFiles = true;
+const handleTraceFolders = false;
+
+//The base extension will only provide support for trace files, and not for trace folders
+importedApi.setHandleTraceResourceType(handleTraceFiles, handleTraceFolders);
 ```

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -85,7 +85,7 @@
         "icon": "assets/media/dep.svg"
       },
       {
-        "command": "openedTraces.openTraceFolder",
+        "command": "openedTraces.openTrace",
         "title": "Open Trace",
         "icon": "$(new-folder)"
       },
@@ -165,7 +165,7 @@
       {
         "view": "welcome",
         "name": "Open Trace",
-        "contents": "There are currently no opened traces. \n[Open Trace](command:openedTraces.openTraceFolder)",
+        "contents": "There are currently no opened traces.\n[Open Trace](command:openedTraces.openTrace)",
         "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
       },
       {
@@ -178,7 +178,7 @@
     "menus": {
       "view/title": [
         {
-          "command": "openedTraces.openTraceFolder",
+          "command": "openedTraces.openTrace",
           "when": "view == traceExplorer.openedTracesView && !trace-explorer.noExperiments",
           "group": "navigation"
         },
@@ -304,7 +304,6 @@
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-react": "^7.20.0",
-    
     "rimraf": "^2.6.3",
     "source-map-loader": "^1.0.2",
     "style-loader": "^2.0.0",

--- a/vscode-trace-extension/src/external-api/external-api.ts
+++ b/vscode-trace-extension/src/external-api/external-api.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { traceExtensionWebviewManager, traceServerManager } from '../extension';
 import { TraceServerContributor } from '../utils/trace-server-manager';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
+import { TraceExplorerResourceTypeHandler } from '../utils/trace-explorer-resource-type-handler';
 
 export interface ExternalAPI {
     getActiveExperiment(): Experiment | undefined;
@@ -19,6 +20,7 @@ export interface ExternalAPI {
     onSignalManagerSignal(event: string | symbol, listener: (...args: unknown[]) => void): void;
     offSignalManagerSignal(event: string | symbol, listener: (...args: unknown[]) => void): void;
     addTraceServerContributor(contributor: TraceServerContributor): void;
+    setHandleTraceResourceType(handleFiles: boolean, handleFolders: boolean): void;
 }
 
 export const traceExtensionAPI: ExternalAPI = {
@@ -94,5 +96,16 @@ export const traceExtensionAPI: ExternalAPI = {
      */
     addTraceServerContributor(contributor: TraceServerContributor): void {
         traceServerManager.addTraceServerContributor(contributor);
+    },
+
+    /**
+     * Sets the trace resouce types that the extension can handle. Extending can set if the extension handles
+     * trace files, trace folders or both.
+     *
+     * @param handleFiles sets handling of trace files
+     * @param handleFolders sets handling of trace folders
+     */
+    setHandleTraceResourceType(handleFiles: boolean, handleFolders: boolean): void {
+        TraceExplorerResourceTypeHandler.getInstance().setHandleResourceTypes(handleFiles, handleFolders);
     }
 };

--- a/vscode-trace-extension/src/test/extension-test.spec.ts
+++ b/vscode-trace-extension/src/test/extension-test.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Locator } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
     await page.goto('http://localhost:3000');
@@ -16,12 +16,40 @@ test('Open Trace from Explorer', async ({ page }) => {
 
 test('Open Trace from Trace Viewer', async ({ page }) => {
     await page.getByRole('tab', { name: 'Trace Viewer' }).locator('a').click();
-    await page.getByLabel('Opened Traces Section').hover();
+
+    // Locate the welcome view button or the open traces view (when trace exists already)
+    const index = await waitForFirstLocator([
+        page.getByLabel('Opened Traces Section'),
+        page.getByRole('button', { name: 'Open Trace' })
+    ]);
+
+    if (index === 0) {
+        await page.getByLabel('Opened Traces Section').hover();
+    }
+
     await page.getByRole('button', { name: 'Open Trace' }).hover();
     await page.getByRole('button', { name: 'Open Trace' }).click();
+    await page.getByRole('option', { name: 'Folder' }).locator('a').click();
     await page.getByRole('option', { name: '202-bug-hunt' }).locator('a').click();
     await page.getByRole('option', { name: 'cat-kernel' }).locator('a').click();
     await page.waitForTimeout(1000);
     await page.getByRole('button', { name: 'OK' }).click();
     await expect(page.getByRole('tab', { name: 'cat-kernel' })).toBeVisible();
 });
+
+export async function waitForFirstLocator(locators: Locator[]): Promise<number> {
+    // return the first promise that resolves
+    const res = await Promise.race([
+        ...locators.map(async (locator, index): Promise<number> => {
+            let timedOut = false;
+            await locator.waitFor({ state: 'visible' }).catch(() => (timedOut = true));
+            return timedOut ? -1 : index;
+        })
+    ]);
+
+    // None of the locators resolved - throw error
+    if (res === -1) {
+        throw new Error('TimedOut: locators provided were not visible');
+    }
+    return res;
+}

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -106,7 +106,7 @@ export class TraceExplorerOpenedTracesViewProvider extends AbstractTraceExplorer
                         updateNoExperimentsContext();
                         return;
                     case VSCODE_MESSAGES.OPEN_TRACE:
-                        vscode.commands.executeCommand('openedTraces.openTraceFolder');
+                        vscode.commands.executeCommand('openedTraces.openTrace');
                         return;
                     case VSCODE_MESSAGES.EXPERIMENT_SELECTED: {
                         let experiment: Experiment | undefined;

--- a/vscode-trace-extension/src/trace-explorer/trace-utils.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-utils.ts
@@ -35,11 +35,11 @@ export const zoomHandler = (hasZoomedIn: boolean): void => {
     TraceViewerPanel.zoomOnCurrent(hasZoomedIn);
 };
 
-export const openDialog = async (): Promise<vscode.Uri | undefined> => {
+export const openDialog = async (selectFiles = false): Promise<vscode.Uri | undefined> => {
     const props: vscode.OpenDialogOptions = {
-        title: 'Open Trace',
-        canSelectFolders: true,
-        canSelectFiles: false,
+        title: selectFiles ? 'Open Trace File' : 'Open Trace Folder',
+        canSelectFolders: !selectFiles,
+        canSelectFiles: selectFiles,
         canSelectMany: false
     };
     let traceURI = undefined;

--- a/vscode-trace-extension/src/utils/trace-explorer-resource-type-handler.ts
+++ b/vscode-trace-extension/src/utils/trace-explorer-resource-type-handler.ts
@@ -1,0 +1,84 @@
+/***************************************************************************************
+ * Copyright (c) 2024 BlackBerry Limited and others.
+ *
+ * Licensed under the MIT license. See LICENSE file in the project root for details.
+ ***************************************************************************************/
+import * as vscode from 'vscode';
+
+export type ResourceType = 'File' | 'Folder';
+export type ResourceTypeQuickPickItem = vscode.QuickPickItem & { type: ResourceType };
+
+export class TraceExplorerResourceTypeHandler {
+    private static instance: TraceExplorerResourceTypeHandler;
+    private doHandleFiles = true;
+    private doHandleFolders = true;
+    private quickpickItems: ResourceTypeQuickPickItem[] = [
+        { label: 'File', type: 'File' },
+        { label: 'Folder', type: 'Folder' }
+    ];
+
+    private constructor() {
+        /** Empty constructor */
+    }
+
+    public static getInstance(): TraceExplorerResourceTypeHandler {
+        if (!TraceExplorerResourceTypeHandler.instance) {
+            TraceExplorerResourceTypeHandler.instance = new TraceExplorerResourceTypeHandler();
+        }
+        return TraceExplorerResourceTypeHandler.instance;
+    }
+
+    /**
+     * Updates the stored value of whether files and/or folders should be handled by the extension
+     *
+     * @param handleFiles  trace files to be handled
+     * @param handleFolders trace folders to be handled
+     */
+    setHandleResourceTypes(handleFiles: boolean | undefined, handleFolders: boolean | undefined): void {
+        if (handleFiles !== undefined) {
+            this.doHandleFiles = handleFiles;
+        }
+        if (handleFolders !== undefined) {
+            this.doHandleFolders = handleFolders;
+        }
+    }
+
+    /**
+     * Checks if trace folders are handled to by the extension
+     *
+     * @returns true if folders are handled
+     */
+    handleFolders(): boolean {
+        return this.doHandleFolders;
+    }
+
+    /**
+     * Checks if trace files are handled to by the extension
+     * @returns true if files are handled
+     */
+    handleFiles(): boolean {
+        return this.doHandleFiles;
+    }
+
+    /**
+     * Detects what resource type should be handled by the extension based on the set values.
+     * If both file and folder resource types are to be handled, a quick pick is prompted to let the user
+     * decide which type should be handled.
+     *
+     * @returns TraceResourceType to be handled
+     */
+    async detectOrPromptForTraceResouceType(): Promise<ResourceType | undefined> {
+        // Try to figure out from context set
+        if (this.handleFiles() && !this.handleFolders()) {
+            return 'File';
+        } else if (!this.handleFiles() && this.handleFolders()) {
+            return 'Folder';
+        } else {
+            const selection = await vscode.window.showQuickPick(this.quickpickItems, {
+                title: 'Select the trace resource type to open'
+            });
+            if (!selection) return undefined;
+            return selection.type;
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a handler that manages and detects resource type dialog that should be opened when opening a trace. It provides the ability to handle one or both file and folder trace types. If both is handled, a quick pick is shown to select which type of resource dialog should be opened. The functionality to control which trace type should be handle is provided through
the external API.

Signed-off-by: Neel Gondalia <ngondalia@blackberry.com>