### PR TITLE
AbstractTraceExplorerProvider - Code Cleanup

### DIFF
--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -53,12 +53,12 @@ export function activate(context: vscode.ExtensionContext): ExternalAPI {
         vscode.window.registerWebviewViewProvider(TraceExplorerAvailableViewsProvider.viewType, myAnalysisProvider)
     );
 
-    const propertiesProvider = new TraceExplorerItemPropertiesProvider(context.extensionUri);
+    const propertiesProvider = new TraceExplorerItemPropertiesProvider(context.extensionUri, serverStatusService);
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(TraceExplorerItemPropertiesProvider.viewType, propertiesProvider)
     );
 
-    const timeRangeDataProvider = new TraceExplorerTimeRangeDataProvider(context.extensionUri);
+    const timeRangeDataProvider = new TraceExplorerTimeRangeDataProvider(context.extensionUri, serverStatusService);
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(TraceExplorerTimeRangeDataProvider.viewType, timeRangeDataProvider)
     );

--- a/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
@@ -1,0 +1,130 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as vscode from 'vscode';
+import { TraceServerConnectionStatusService } from '../utils/trace-server-status';
+import { getTraceServerUrl } from '../utils/backend-tsp-client-provider';
+import { traceExtensionWebviewManager } from 'vscode-trace-extension/src/extension';
+import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
+
+export abstract class AbstractTraceExplorerProvider implements vscode.WebviewViewProvider {
+    protected _view: vscode.WebviewView;
+    protected _disposables: vscode.Disposable[] = [];
+
+    /**
+     * Bundled JS script file for the webview.
+     * The bundle files are defined in `vscode-trace-webviews/webpack.config.js`
+     */
+    protected abstract readonly _webviewScript: string;
+
+    /**
+     * The `vscode.WebviewOptions` that will be used inside `vscode.WebviewViewProvider.resolveWebviewView`
+     */
+    protected abstract readonly _webviewOptions: vscode.WebviewOptions;
+
+    constructor(
+        protected readonly _extensionUri: vscode.Uri,
+        protected readonly _statusService: TraceServerConnectionStatusService
+    ) {}
+
+    /**
+     * Sends the updated URL to the front-end webview.
+     * Refreshes the HTML to prevent CORS errors.
+     * @param {string} newUrl
+     */
+    public updateTraceServerUrl(newUrl: string): void {
+        if (!this._view) {
+            return;
+        }
+        this._view.webview.postMessage({ command: VSCODE_MESSAGES.TRACE_SERVER_URL_CHANGED, data: newUrl });
+        this._view.webview.html = this._getHtmlForWebview(this._view.webview);
+    }
+
+    /**
+     * Directly sends a VSCode Message to the Provider's Webview.
+     * @param {string} command - command from `VSCODE_MESSAGES` object
+     * @param {unknown} data - payload
+     */
+    public postMessagetoWebview(command: string, data: unknown): void {
+        if (!this._view || command) {
+            return;
+        }
+        this._view.webview.postMessage({ command, data });
+    }
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken
+    ): void {
+        this._view = webviewView;
+        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+        webviewView.webview.options = this._webviewOptions;
+
+        traceExtensionWebviewManager.fireWebviewCreated(webviewView);
+
+        this.init(webviewView, _context, _token);
+    }
+
+    /* eslint-disable max-len */
+    protected _getHtmlForWebview(webview: vscode.Webview) {
+        // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
+        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', this._webviewScript));
+        const codiconsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css')
+        );
+        const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
+
+        // Use a nonce to only allow a specific script to be run.
+        const nonce = getNonce();
+
+        return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
+				<meta name="theme-color" content="#000000">
+				<title>React App</title>
+				<meta http-equiv="Content-Security-Policy"
+					content="default-src 'none';
+					img-src vscode-resource: https:;
+					script-src 'nonce-${nonce}' 'unsafe-eval';
+					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
+					connect-src ${getTraceServerUrl()};
+					font-src ${webview.cspSource}">
+				<link href="${codiconsUri}" rel="stylesheet" />
+				<base href="${packUri}/">
+			</head>
+
+			<body>
+				<noscript>You need to enable JavaScript to run this app.</noscript>
+				<div id="root"></div>
+
+				<script nonce="${nonce}">
+					const vscode = acquireVsCodeApi();
+				</script>
+				<script nonce="${nonce}" src="${scriptUri}"></script>
+			</body>
+			</html>`;
+    }
+
+    /**
+     * Initialize the WebviewViewProvider.
+     * Executes inside of `vscode.WebviewViewProvider.resolveWebviewView`
+     * @param {vscode.WebviewView} webviewView
+     * @param {vscode.WebviewViewResolveContext} _context
+     * @param {vscode.CancellationToken} _token
+     */
+    protected abstract init(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken
+    ): void;
+}
+
+function getNonce() {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
@@ -1,74 +1,51 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import JSONBigConfig from 'json-bigint';
+import * as vscode from 'vscode';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
-import * as vscode from 'vscode';
 import { TraceViewerPanel } from '../../trace-viewer-panel/trace-viewer-webview-panel';
-import { TraceServerConnectionStatusService } from '../../utils/trace-server-status';
-import { getTraceServerUrl, getTspClientUrl } from '../../utils/backend-tsp-client-provider';
+import { getTspClientUrl } from '../../utils/backend-tsp-client-provider';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
-import { traceExtensionWebviewManager } from 'vscode-trace-extension/src/extension';
+import { AbstractTraceExplorerProvider } from '../abstract-trace-explorer-provider';
 
 const JSONBig = JSONBigConfig({
     useNativeBigInt: true
 });
 
-export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewProvider {
+export class TraceExplorerAvailableViewsProvider extends AbstractTraceExplorerProvider {
     public static readonly viewType = 'traceExplorer.availableViews';
+    public readonly _webviewScript = 'analysisPanel.js';
+    protected readonly _webviewOptions = {
+        enableScripts: true,
+        localResourceRoots: [
+            vscode.Uri.joinPath(this._extensionUri, 'pack'),
+            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons')
+        ]
+    };
 
-    private _view?: vscode.WebviewView;
-    private _disposables: vscode.Disposable[] = [];
     private _selectionOngoing = false;
     private _selectedExperiment: Experiment | undefined;
 
-    private _onExperimentSelected = (experiment: Experiment | undefined): void =>
-        this.doHandleExperimentSelectedSignal(experiment);
-
-    constructor(
-        private readonly _extensionUri: vscode.Uri,
-        private readonly _statusService: TraceServerConnectionStatusService
-    ) {}
-
-    public updateTraceServerUrl(newUrl: string): void {
-        if (this._view) {
-            this._view.webview.postMessage({ command: VSCODE_MESSAGES.TRACE_SERVER_URL_CHANGED, data: newUrl });
-            this._view.webview.html = this._getHtmlForWebview(this._view.webview);
-        }
-    }
-
-    public resolveWebviewView(
+    protected init(
         webviewView: vscode.WebviewView,
         _context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken
     ): void {
-        this._view = webviewView;
-
-        webviewView.webview.options = {
-            // Allow scripts in the webview
-            enableScripts: true,
-
-            localResourceRoots: [
-                vscode.Uri.joinPath(this._extensionUri, 'pack'),
-                vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons')
-            ]
-        };
-
-        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
-        traceExtensionWebviewManager.fireWebviewCreated(webviewView);
-
-        // Handle messages from the webview
         webviewView.webview.onDidReceiveMessage(
             message => {
-                switch (message.command) {
+                const command: string = message.command;
+                const data: any = message.data;
+                switch (command) {
                     case VSCODE_MESSAGES.CONNECTION_STATUS:
-                        if (message.data && message.data.status) {
+                        if (data && data.status) {
                             this._statusService.checkAndUpdateServerStatus();
                         }
                         return;
                     case VSCODE_MESSAGES.WEBVIEW_READY:
                         // Post the tspTypescriptClient
-                        webviewView.webview.postMessage({
+                        this._view.webview.postMessage({
                             command: VSCODE_MESSAGES.SET_TSP_CLIENT,
                             data: getTspClientUrl()
                         });
@@ -77,23 +54,23 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
                         }
                         return;
                     case VSCODE_MESSAGES.OUTPUT_ADDED:
-                        if (message.data && message.data.descriptor) {
+                        if (data && data.descriptor) {
                             // FIXME: JSONBig.parse() created bigint if numbers are small.
                             // Not an issue right now for output descriptors.
-                            const descriptor = JSONBig.parse(message.data.descriptor) as OutputDescriptor;
+                            const descriptor = JSONBig.parse(data.descriptor) as OutputDescriptor;
                             // TODO: Don't use static current panel, i.e. find better design to add output...
 
                             TraceViewerPanel.addOutputToCurrent(descriptor);
-                            // const panel = TraceViewerPanel.createOrShow(this._extensionUri, message.data.experiment.name);
-                            // panel.setExperiment(message.data.experiment);
+                            // const panel = TraceViewerPanel.createOrShow(this._extensionUri, data.experiment.name);
+                            // panel.setExperiment(data.experiment);
                         }
                         return;
                     case VSCODE_MESSAGES.EXPERIMENT_SELECTED: {
                         try {
                             this._selectionOngoing = true;
-                            if (message.data && message.data.wrapper) {
+                            if (data && data.wrapper) {
                                 // Avoid endless forwarding of signal
-                                this._selectedExperiment = convertSignalExperiment(JSONBig.parse(message.data.wrapper));
+                                this._selectedExperiment = convertSignalExperiment(JSONBig.parse(data.wrapper));
                             } else {
                                 this._selectedExperiment = undefined;
                             }
@@ -118,6 +95,9 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
         );
     }
 
+    private _onExperimentSelected = (experiment: Experiment | undefined): void =>
+        this.doHandleExperimentSelectedSignal(experiment);
+
     protected doHandleExperimentSelectedSignal(experiment: Experiment | undefined): void {
         if (!this._selectionOngoing && this._view) {
             this._selectedExperiment = experiment;
@@ -125,55 +105,4 @@ export class TraceExplorerAvailableViewsProvider implements vscode.WebviewViewPr
             this._view.webview.postMessage({ command: VSCODE_MESSAGES.EXPERIMENT_SELECTED, data: wrapper });
         }
     }
-
-    /* eslint-disable max-len */
-    private _getHtmlForWebview(webview: vscode.Webview) {
-        // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'analysisPanel.js'));
-        const codiconsUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css')
-        );
-        const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
-
-        // Use a nonce to only allow a specific script to be run.
-        const nonce = getNonce();
-
-        return `<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="utf-8">
-				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
-				<meta name="theme-color" content="#000000">
-				<title>React App</title>
-				<meta http-equiv="Content-Security-Policy"
-					content="default-src 'none';
-					img-src vscode-resource: https:;
-					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
-					connect-src ${getTraceServerUrl()};
-					font-src ${webview.cspSource}">
-				<link href="${codiconsUri}" rel="stylesheet" />
-				<base href="${packUri}/">
-			</head>
-
-			<body>
-				<noscript>You need to enable JavaScript to run this app.</noscript>
-				<div id="root"></div>
-
-				<script nonce="${nonce}">
-					const vscode = acquireVsCodeApi();
-				</script>
-				<script nonce="${nonce}" src="${scriptUri}"></script>
-			</body>
-			</html>`;
-    }
-}
-
-function getNonce() {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
 }

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -1,33 +1,30 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import JSONBigConfig from 'json-bigint';
 import { signalManager, Signals } from 'traceviewer-base/lib/signals/signal-manager';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import * as vscode from 'vscode';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import { TraceViewerPanel } from '../../trace-viewer-panel/trace-viewer-webview-panel';
-import { TraceServerConnectionStatusService } from '../../utils/trace-server-status';
-import {
-    getTraceServerUrl,
-    getTspClientUrl,
-    updateNoExperimentsContext
-} from '../../utils/backend-tsp-client-provider';
+import { getTspClientUrl, updateNoExperimentsContext } from '../../utils/backend-tsp-client-provider';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
-import { traceExtensionWebviewManager } from 'vscode-trace-extension/src/extension';
+import { AbstractTraceExplorerProvider } from '../abstract-trace-explorer-provider';
 
 const JSONBig = JSONBigConfig({
     useNativeBigInt: true
 });
 
-export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewViewProvider {
+export class TraceExplorerOpenedTracesViewProvider extends AbstractTraceExplorerProvider {
     public static readonly viewType = 'traceExplorer.openedTracesView';
+    protected readonly _webviewScript = 'openedTracesPanel.js';
+    protected readonly _webviewOptions = {
+        enableScripts: true,
+        localResourceRoots: [
+            vscode.Uri.joinPath(this._extensionUri, 'pack'),
+            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons')
+        ]
+    };
 
-    private _view?: vscode.WebviewView;
-    private _disposables: vscode.Disposable[] = [];
     private _selectedExperiment: Experiment | undefined;
-
-    constructor(
-        private readonly _extensionUri: vscode.Uri,
-        private readonly _statusService: TraceServerConnectionStatusService
-    ) {}
 
     private _onOpenedTracesWidgetActivated = (experiment: Experiment): void =>
         this.doHandleTracesWidgetActivatedSignal(experiment);
@@ -57,45 +54,24 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
         }
     }
 
-    public updateTraceServerUrl(newUrl: string): void {
-        if (this._view) {
-            this._view.webview.postMessage({ command: VSCODE_MESSAGES.TRACE_SERVER_URL_CHANGED, data: newUrl });
-            this._view.webview.html = this._getHtmlForWebview(this._view.webview);
-        }
-    }
-
-    public resolveWebviewView(
+    protected init(
         webviewView: vscode.WebviewView,
         _context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken
     ): void {
-        this._view = webviewView;
-
-        webviewView.webview.options = {
-            // Allow scripts in the webview
-            enableScripts: true,
-
-            localResourceRoots: [
-                vscode.Uri.joinPath(this._extensionUri, 'pack'),
-                vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons')
-            ]
-        };
-
-        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
-        traceExtensionWebviewManager.fireWebviewCreated(webviewView);
-
-        // Handle messages from the webview
         webviewView.webview.onDidReceiveMessage(
             message => {
-                switch (message.command) {
+                const command: string = message.command;
+                const data: any = message.data;
+                switch (command) {
                     case VSCODE_MESSAGES.CONNECTION_STATUS:
-                        if (message.data && message.data.status) {
+                        if (data && data.status) {
                             this._statusService.checkAndUpdateServerStatus();
                         }
                         return;
                     case VSCODE_MESSAGES.WEBVIEW_READY:
                         // Post the tspTypescriptClient
-                        webviewView.webview.postMessage({
+                        this._view.webview.postMessage({
                             command: VSCODE_MESSAGES.SET_TSP_CLIENT,
                             data: getTspClientUrl()
                         });
@@ -107,8 +83,8 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
                         }
                         return;
                     case VSCODE_MESSAGES.RE_OPEN_TRACE:
-                        if (message.data && message.data.wrapper) {
-                            const experiment = convertSignalExperiment(JSONBig.parse(message.data.wrapper));
+                        if (data && data.wrapper) {
+                            const experiment = convertSignalExperiment(JSONBig.parse(data.wrapper));
                             const panel = TraceViewerPanel.createOrShow(
                                 this._extensionUri,
                                 experiment.name,
@@ -120,9 +96,9 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
                         return;
                     case VSCODE_MESSAGES.CLOSE_TRACE:
                     case VSCODE_MESSAGES.DELETE_TRACE:
-                        if (message.data && message.data.wrapper) {
+                        if (data && data.wrapper) {
                             // just remove the panel here
-                            TraceViewerPanel.disposePanel(this._extensionUri, JSONBig.parse(message.data.wrapper).name);
+                            TraceViewerPanel.disposePanel(this._extensionUri, JSONBig.parse(data.wrapper).name);
                             signalManager().fireExperimentSelectedSignal(undefined);
                         }
                         return;
@@ -134,8 +110,8 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
                         return;
                     case VSCODE_MESSAGES.EXPERIMENT_SELECTED: {
                         let experiment: Experiment | undefined;
-                        if (message.data && message.data.wrapper) {
-                            experiment = convertSignalExperiment(JSONBig.parse(message.data.wrapper));
+                        if (data && data.wrapper) {
+                            experiment = convertSignalExperiment(JSONBig.parse(data.wrapper));
                         } else {
                             experiment = undefined;
                         }
@@ -150,74 +126,15 @@ export class TraceExplorerOpenedTracesViewProvider implements vscode.WebviewView
         signalManager().on(Signals.TRACEVIEWERTAB_ACTIVATED, this._onOpenedTracesWidgetActivated);
         signalManager().on(Signals.EXPERIMENT_SELECTED, this._onExperimentSelected);
         signalManager().on(Signals.EXPERIMENT_OPENED, this._onExperimentOpened);
+
         webviewView.onDidDispose(
             _event => {
                 signalManager().off(Signals.TRACEVIEWERTAB_ACTIVATED, this._onOpenedTracesWidgetActivated);
                 signalManager().off(Signals.EXPERIMENT_SELECTED, this._onExperimentSelected);
+                signalManager().off(Signals.EXPERIMENT_OPENED, this._onExperimentOpened);
             },
             undefined,
             this._disposables
         );
     }
-
-    postMessagetoWebview(_command: string, _data: unknown): void {
-        if (this._view && _command) {
-            if (_data) {
-                this._view.webview.postMessage({ command: _command, data: _data });
-            } else {
-                this._view.webview.postMessage({ command: _command });
-            }
-        }
-    }
-
-    /* eslint-disable max-len */
-    private _getHtmlForWebview(webview: vscode.Webview) {
-        // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'openedTracesPanel.js'));
-        const codiconsUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css')
-        );
-        const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
-
-        // Use a nonce to only allow a specific script to be run.
-        const nonce = getNonce();
-
-        return `<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="utf-8">
-				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
-				<meta name="theme-color" content="#000000">
-				<title>React App</title>
-				<meta http-equiv="Content-Security-Policy"
-					content="default-src 'none';
-					img-src vscode-resource: https:;
-					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
-					connect-src ${getTraceServerUrl()};
-					font-src ${webview.cspSource}">
-				<link href="${codiconsUri}" rel="stylesheet" />
-				<base href="${packUri}/">
-			</head>
-
-			<body>
-				<noscript>You need to enable JavaScript to run this app.</noscript>
-				<div id="root"></div>
-
-				<script nonce="${nonce}">
-					const vscode = acquireVsCodeApi();
-				</script>
-				<script nonce="${nonce}" src="${scriptUri}"></script>
-			</body>
-			</html>`;
-    }
-}
-
-function getNonce() {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
 }

--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -4,94 +4,20 @@
  * Licensed under the MIT license. See LICENSE file in the project root for details.
  ***************************************************************************************/
 import * as vscode from 'vscode';
-import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
-import { traceExtensionWebviewManager } from 'vscode-trace-extension/src/extension';
-import { getTraceServerUrl } from 'vscode-trace-extension/src/utils/backend-tsp-client-provider';
+import { AbstractTraceExplorerProvider } from '../abstract-trace-explorer-provider';
 
-export class TraceExplorerItemPropertiesProvider implements vscode.WebviewViewProvider {
+export class TraceExplorerItemPropertiesProvider extends AbstractTraceExplorerProvider {
     public static readonly viewType = 'traceExplorer.itemPropertiesView';
-    private _view?: vscode.WebviewView;
-    constructor(private readonly _extensionUri: vscode.Uri) {}
+    public readonly _webviewScript = 'propertiesPanel.js';
+    protected readonly _webviewOptions = {
+        enableScripts: true,
+        localResourceRoots: [
+            vscode.Uri.joinPath(this._extensionUri, 'pack'),
+            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons')
+        ]
+    };
 
-    resolveWebviewView(
-        webviewView: vscode.WebviewView,
-        _context: vscode.WebviewViewResolveContext,
-        _token: vscode.CancellationToken
-    ): void {
-        this._view = webviewView;
-        webviewView.webview.options = {
-            // Allow scripts in the webview
-            enableScripts: true,
-            localResourceRoots: [
-                vscode.Uri.joinPath(this._extensionUri, 'pack'),
-                vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons')
-            ]
-        };
-        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
-        traceExtensionWebviewManager.fireWebviewCreated(webviewView);
+    protected init(): void {
+        return;
     }
-
-    postMessagetoWebview(_command: string, _data: unknown): void {
-        if (this._view && _command && _data) {
-            this._view.webview.postMessage({ command: _command, data: _data });
-        }
-    }
-
-    public updateTraceServerUrl(newUrl: string): void {
-        if (this._view) {
-            this._view.webview.postMessage({ command: VSCODE_MESSAGES.TRACE_SERVER_URL_CHANGED, data: newUrl });
-            this._view.webview.html = this._getHtmlForWebview(this._view.webview);
-        }
-    }
-
-    /* eslint-disable max-len */
-    private _getHtmlForWebview(webview: vscode.Webview) {
-        // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'propertiesPanel.js'));
-        const codiconsUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this._extensionUri, 'lib', 'codicons', 'codicon.css')
-        );
-        const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
-
-        // Use a nonce to only allow a specific script to be run.
-        const nonce = getNonce();
-
-        return `<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="utf-8">
-				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
-				<meta name="theme-color" content="#000000">
-				<title>React App</title>
-				<meta http-equiv="Content-Security-Policy"
-					content="default-src 'none';
-					img-src vscode-resource: https:;
-					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
-					connect-src ${getTraceServerUrl()};
-                    font-src ${webview.cspSource}">
-				<link href="${codiconsUri}" rel="stylesheet" />
-                <base href="${packUri}/">
-			</head>
-
-			<body>
-				<noscript>You need to enable JavaScript to run this app.</noscript>
-				<div id="root"></div>
-				
-                <script nonce="${nonce}">
-					const vscode = acquireVsCodeApi();
-				</script>
-                <script nonce="${nonce}" src="${scriptUri}"></script>
-            </body>
-			</html>`;
-    }
-}
-
-function getNonce() {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
 }

--- a/vscode-trace-extension/src/trace-explorer/time-range/trace-explorer-time-range-data-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/time-range/trace-explorer-time-range-data-webview-provider.ts
@@ -1,38 +1,30 @@
 import * as vscode from 'vscode';
-import { getTraceServerUrl } from 'vscode-trace-extension/src/utils/backend-tsp-client-provider';
 import JSONBigConfig from 'json-bigint';
 import { Signals, signalManager } from 'traceviewer-base/lib/signals/signal-manager';
 import { TimeRangeUpdatePayload } from 'traceviewer-base/lib/signals/time-range-data-signal-payloads';
 import { TimeRangeDataMap } from 'traceviewer-react-components/lib/components/utils/time-range-data-map';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
+import { AbstractTraceExplorerProvider } from '../abstract-trace-explorer-provider';
 
 const JSONBig = JSONBigConfig({
     useNativeBigInt: true
 });
 
-export class TraceExplorerTimeRangeDataProvider implements vscode.WebviewViewProvider {
+export class TraceExplorerTimeRangeDataProvider extends AbstractTraceExplorerProvider {
     public static readonly viewType = 'traceExplorer.timeRangeDataView';
-    private _view: vscode.WebviewView;
-    private _disposables: vscode.Disposable[] = [];
-    private _experimentDataMap: TimeRangeDataMap;
-    constructor(private readonly _extensionUri: vscode.Uri) {
-        this._experimentDataMap = new TimeRangeDataMap();
-    }
+    protected readonly _webviewScript = 'timeRangePanel.js';
+    protected readonly _webviewOptions = {
+        enableScripts: true,
+        localResourceRoots: [vscode.Uri.joinPath(this._extensionUri, 'pack')]
+    };
+    private _experimentDataMap = new TimeRangeDataMap();
 
-    resolveWebviewView(
+    protected init(
         webviewView: vscode.WebviewView,
         _context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken
     ): void {
-        this._view = webviewView;
-        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
-        webviewView.webview.options = {
-            // Allow scripts in the webview
-            enableScripts: true,
-            localResourceRoots: [vscode.Uri.joinPath(this._extensionUri, 'pack')]
-        };
-
         webviewView.webview.onDidReceiveMessage(
             message => {
                 const command = message?.command;
@@ -82,13 +74,6 @@ export class TraceExplorerTimeRangeDataProvider implements vscode.WebviewViewPro
         );
     }
 
-    public updateTraceServerUrl(newUrl: string): void {
-        if (this._view) {
-            this._view.webview.postMessage({ command: VSCODE_MESSAGES.TRACE_SERVER_URL_CHANGED, data: newUrl });
-            this._view.webview.html = this._getHtmlForWebview(this._view.webview);
-        }
-    }
-
     private onViewRangeUpdated = (update: TimeRangeUpdatePayload) => {
         this._view.webview.postMessage({
             command: VSCODE_MESSAGES.VIEW_RANGE_UPDATED,
@@ -130,45 +115,4 @@ export class TraceExplorerTimeRangeDataProvider implements vscode.WebviewViewPro
         this._view.webview.postMessage({ command: VSCODE_MESSAGES.TRACE_VIEWER_TAB_CLOSED, data: experimentUUID });
         this._experimentDataMap.delete(experimentUUID);
     };
-
-    /* eslint-disable max-len */
-    private _getHtmlForWebview(webview: vscode.Webview) {
-        // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack', 'timeRangePanel.js'));
-        const packUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'pack'));
-
-        // Use a nonce to only allow a specific script to be run.
-        const nonce = getNonce();
-
-        return `<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="utf-8">
-				<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
-				<meta name="theme-color" content="#000000">
-				<title>React App</title>
-				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src vscode-resource: https:; script-src 'nonce-${nonce}' 'unsafe-eval';style-src vscode-resource: 'unsafe-inline' http: https: data:;connect-src ${getTraceServerUrl()};">
-				<base href="${packUri}/">
-			</head>
-
-			<body>
-				<noscript>You need to enable JavaScript to run this app.</noscript>
-				<div id="root"></div>
-				
-                <script nonce="${nonce}">
-					const vscode = acquireVsCodeApi();
-				</script>
-                <script nonce="${nonce}" src="${scriptUri}"></script>
-            </body>
-			</html>`;
-    }
-}
-
-function getNonce() {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
 }


### PR DESCRIPTION
Factors out common logic from all WebviewViewProviders into a new
AbstractTraceExplorerProvider abstract class.  This allows for shared
functionality between WebviewViewProviders to be modified in a single
place instead of each individual file.  DRYs out the code.

Signed-off-by: Will Yang <william.yang@ericsson.com>