### PR TITLE
Add Semi-Opaque 'Server Offline' UI Blocker in TraceViewerPanels

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -135,6 +135,20 @@ export class TraceViewerPanel {
         }
     }
 
+    /**
+     * Directly sends a VSCode Message to all activePanel's webviews.
+     * @param {string} command - command from `VSCODE_MESSAGES` object
+     * @param {unknown} data - payload
+     */
+    public static postMessageToWebviews(command: string, data: unknown): void {
+        Object.values(TraceViewerPanel.activePanels).forEach(activePanel => {
+            if (!activePanel?._panel) {
+                return;
+            }
+            activePanel._panel.webview.postMessage({ command, data });
+        });
+    }
+
     public static updateTraceServerUrl(newUrl: string): void {
         Object.values(TraceViewerPanel.activePanels).forEach(trace => {
             if (trace) {

--- a/vscode-trace-webviews/src/trace-viewer/index.css
+++ b/vscode-trace-webviews/src/trace-viewer/index.css
@@ -10,3 +10,26 @@ body {
     width: 100%;
     position: absolute;
 }
+
+.overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Semi-opaque black background */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 999; /* Ensure the overlay appears on top */
+}
+
+.overlay-message {
+    color: white;
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    padding: 20px;
+    border-radius: 5px;
+    user-select: none;
+}

--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -36,6 +36,7 @@ interface VscodeAppState {
     outputs: OutputDescriptor[];
     overviewOutputDescriptor: OutputDescriptor | undefined;
     theme: string;
+    serverStatus: boolean;
 }
 
 class TraceViewerContainer extends React.Component<{}, VscodeAppState> {
@@ -103,7 +104,8 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState> {
             tspClientProvider: undefined,
             outputs: [],
             overviewOutputDescriptor: undefined,
-            theme: 'light'
+            theme: 'light',
+            serverStatus: true
         };
         this._signalHandler = new VsCodeMessageManager();
 
@@ -207,6 +209,12 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState> {
                             );
                         this.contributeContextMenu(ctxMenuPayload);
                     }
+                    break;
+                case VSCODE_MESSAGES.CONNECTION_STATUS:
+                    const serverStatus: boolean = JSONBig.parse(message.data);
+                    console.log('CONNECTION STATUS:', serverStatus);
+                    this.setState({ serverStatus });
+                    break;
             }
         });
         window.addEventListener('resize', this.onResize);
@@ -506,6 +514,13 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState> {
                         removeResizeHandler={this.removeResizeHandler}
                         backgroundTheme={this.state.theme}
                     ></TraceContextComponent>
+                )}
+                {this.state.serverStatus === false && (
+                    <div className="overlay">
+                        <div className="overlay-message">
+                            Please start a trace server to resume using the Trace Viewer.
+                        </div>
+                    </div>
                 )}
             </div>
         );


### PR DESCRIPTION
Add UI blocking overlay when server is offline.  This is to prevent the pending-requests issue in the remote use case and also prevents breaking ui states in the local use case.

Modifies the TraceServerConnectionStatusService to send a vscode message informing all active webviews (views and panels) of the change in server status. Adds a public method in TraceViewerPanel class that sends a vscode message to all active panels.

Signed-off-by: Will Yang <william.yang@ericsson.com>