### PR TITLE
Make playwright tests more stable

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './vscode-trace-extension/src/test/',
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -19,6 +19,12 @@ export default defineConfig({
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+  },
+  /* test timeout */
+  timeout: 60 * 1000,
+  expect: {
+    /* expect timeout */
+    timeout: 40 * 1000,
   },
 
   /* Configure projects for major browsers */

--- a/vscode-trace-extension/src/test/extension-test.spec.ts
+++ b/vscode-trace-extension/src/test/extension-test.spec.ts
@@ -12,10 +12,13 @@ test('Open Trace from Explorer', async ({ page }) => {
     await page.getByRole('menuitem', { name: 'Open with Trace Viewer' }).hover();
     await page.getByRole('menuitem', { name: 'Open with Trace Viewer' }).click();
     await expect(page.getByRole('tab', { name: 'cat-kernel' })).toBeVisible();
+    await page.getByRole('tab', { name: 'Trace Viewer' }).locator('a').click();
+    await expect(page.getByLabel('Opened Traces Section')).toBeVisible();
 });
 
 test('Open Trace from Trace Viewer', async ({ page }) => {
     await page.getByRole('tab', { name: 'Trace Viewer' }).locator('a').click();
+    await expect(page.getByLabel('Opened Traces Section')).toBeVisible();
     await page.getByLabel('Opened Traces Section').hover();
     await page.getByRole('button', { name: 'Open Trace' }).hover();
     await page.getByRole('button', { name: 'Open Trace' }).click();


### PR DESCRIPTION
- Run tests serial: There is only one server and test can interfere each other
- Wait for Open Traces section to be visible
- Increase timeouts due slow opening of traces and switching views

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>