### PR TITLE
Fixed message passing to webviews via AbstractTraceExplorerProvider

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
@@ -44,7 +44,7 @@ export abstract class AbstractTraceExplorerProvider implements vscode.WebviewVie
      * @param {unknown} data - payload
      */
     public postMessagetoWebview(command: string, data: unknown): void {
-        if (!this._view || command) {
+        if (!this._view || !command) {
             return;
         }
         this._view.webview.postMessage({ command, data });


### PR DESCRIPTION
Fixed bug in postMessagetoWebview method of AbstractTraceExplorerProvider. The method returned on a valid command causing some views to break (Item Properties view)

Signed-off-by: Neel Gondalia <ngondalia@blackberry.com>