### PR TITLE
Remove duplicate dispose listener in opened traces view provider

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -127,16 +127,6 @@ export class TraceExplorerOpenedTracesViewProvider extends AbstractTraceExplorer
         signalManager().on(Signals.TRACEVIEWERTAB_ACTIVATED, this._onOpenedTracesWidgetActivated);
         signalManager().on(Signals.EXPERIMENT_SELECTED, this._onExperimentSelected);
         signalManager().on(Signals.EXPERIMENT_OPENED, this._onExperimentOpened);
-
-        webviewView.onDidDispose(
-            _event => {
-                signalManager().off(Signals.TRACEVIEWERTAB_ACTIVATED, this._onOpenedTracesWidgetActivated);
-                signalManager().off(Signals.EXPERIMENT_SELECTED, this._onExperimentSelected);
-                signalManager().off(Signals.EXPERIMENT_OPENED, this._onExperimentOpened);
-            },
-            undefined,
-            this._disposables
-        );
     }
     protected dispose() {
         signalManager().off(Signals.TRACEVIEWERTAB_ACTIVATED, this._onOpenedTracesWidgetActivated);


### PR DESCRIPTION
see `TraceExplorerOpenedTracesViewProvider`

This was missed in commit https://github.com/eclipse-cdt-cloud/vscode-trace-extension/commit/77bf4f03c44677685bcb4ae92003d7f43f3a0be8.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>