### PR TITLE
Fix handling of state in doHandleOutputAddedMessage

### DIFF
--- a/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
+++ b/vscode-trace-webviews/src/trace-viewer/vscode-trace-viewer-container.tsx
@@ -306,8 +306,8 @@ class TraceViewerContainer extends React.Component<{}, VscodeAppState> {
 
     protected async doHandleOutputAddedMessage(descriptor: OutputDescriptor): Promise<void> {
         if (!this.state.outputs.find(output => output.id === descriptor.id)) {
-            await this.fetchAnnotationCategories(descriptor);
             this.setState({ outputs: [...this.state.outputs, descriptor] });
+            await this.fetchAnnotationCategories(descriptor);
         }
     }
 


### PR DESCRIPTION
This method is doing a check on the state to see if output descriptor already exists. In the case it is not found, it had a blocking call before updating the state. This resulted in subsequent signals received directly after the first one, to handle the same output descriptor again.

The outcome of this was that there would be descriptors with the same key being rendered causing errors.

Signed-off-by: Neel Gondalia <ngondalia@blackberry.com>