### PR TITLE
[ci] harmonize release doc, add dhelper scripts

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: [18]
     # Only execute when the trigger was a tag (new release)
-    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'eclipse-cdt-cloud/vscode-trace-extension'
 
     steps:
       - uses: actions/checkout@v4
@@ -128,7 +128,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: [18]
     # Only execute when the trigger was a tag (new release)
-    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'eclipse-cdt-cloud/vscode-trace-extension'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,38 @@
 name: Create or prepare GitHub release
 
 on:
-    push:
-        branches:    
-          - master
-        paths:
-          - 'RELEASE'
-    pull_request:
-        types: [opened, synchronize]
-        branches:
-          - master
-        paths:
-          - 'RELEASE'
+  push:
+    branches:    
+      - master
+    paths:
+      - 'RELEASE'
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+    paths:
+      - 'RELEASE'
 
 jobs:
-    gh-release:
-        name: GitHub release
-        runs-on: ubuntu-latest
-        
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                fetch-depth: 0
-            - uses: pipe-cd/actions-gh-release@v2.6.0
-              with:
-                release_file: 'RELEASE'
-                # Actions that run using the auto-generated GitHub token are
-                # not allowed to trigger a new workflow run. In this case we want
-                # the tag created by actions-gh-release to trigger the main workflow
-                # and result in publishing the extension to open-vsx.
-                # The following scopes are required when creating the committer token:
-                #  - repo:status, repo_deployment, public_repo, read:org
-                # See here for more details:
-                # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
-                token: ${{ secrets.GH_COMMITTER_TOKEN }}
-              
+  gh-release:
+    name: GitHub release
+    if: github.repository == 'eclipse-cdt-cloud/vscode-trace-extension'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pipe-cd/actions-gh-release@v2.6.0
+        with:
+          release_file: 'RELEASE'
+          # Actions that run using the auto-generated GitHub token are
+          # not allowed to trigger a new workflow run. In this case we want
+          # the tag created by actions-gh-release to trigger the main workflow
+          # and result in publishing the extension to open-vsx.
+          # The following scopes are required when creating the committer token:
+          #  - repo:status, repo_deployment, public_repo, read:org
+          # See here for more details:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          token: ${{ secrets.GH_COMMITTER_TOKEN }}
+            

--- a/README.md
+++ b/README.md
@@ -363,3 +363,35 @@ Forwarded ports can be seen in the 'Ports' view of the remote VsCode.  To open t
 Make sure that there is no Trace Server running on your local host. If the `Trace Viewer for VSCode` is unresponsive, stop the port forwarding by pressing the 'Stop Port Fowarding (Delete)' of the trace server port and restart remote VSCode.
 
 If you are a developers of the `Trace Viewer for VsCode` and want to modify and test the extension, you can [package it as a VSCode extension (.vsix)](#package-as-a-vscode-extension-vsix), upload the `VSIX` to the remote host and install the extension using the `Install from VSIX...` view menu of the `Extensions` view.
+
+## Release/publish
+
+We use GitHub CI to create a GitHub release and the corresponding git tag, and also to publish this repo's VSCode extension to the `open-vsx.org` and the `Visual Studio Marketplace` registries.
+
+### Triggering a new release
+
+Whenever a new release is desired, it can be triggered through a PR, as per the following:
+
+Create a new branch for your PR, based on the repo's latest state. e.g.
+
+```bash
+git branch new-release && git checkout new-release
+```
+
+Then decide if the release shall be a `Major`, `Minor` or `Patch` release and use the corresponding command below to step the package's versions, according to the release type. A new release commit will be created:
+
+``` bash
+yarn version:major
+# or
+yarn version:minor
+# or
+yarn version:patch
+```
+
+Modify the _version tag_ in file `./RELEASE`, to match the new release. Amend the release commit to include this change:
+
+```bash
+git add RELEASE && git commit --amend
+```
+
+Finally, push the branch to the main repository (not a fork!) and use it to create a PR. When the PR is merged, a GitHub release should be created with auto-generated release notes, as well as a git tag. Then the `publish-*` CI jobs should trigger, and if everything goes well, publish the new version of the extension to both registries.

--- a/lerna.json
+++ b/lerna.json
@@ -1,13 +1,9 @@
 {
-  "version": "independent",
-  "npmClient": "yarn",
-  "command": {
-    "run": {
-      "stream": true
+    "version": "0.2.5",
+    "npmClient": "yarn",
+    "command": {
+        "run": {
+            "stream": true
+        }
     }
-  },
-  "packages": [
-    "vscode-*"
-  ]
 }
-

--- a/package.json
+++ b/package.json
@@ -1,33 +1,36 @@
 {
-  "private": true,
-  "scripts": {
-    "prepare": "lerna run prepare",
-    "watch": "lerna exec --stream --parallel -- \"yarn run watch\"",
-    "clean": "lerna run clean",
-    "vsce:package": "lerna run vsce:package",
-    "lint": "lerna run lint",
-    "format:write": "lerna run format:write",
-    "format:check": "lerna run format:check",
-    "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
-    "start:server": "./trace-compass-server/tracecompass-server",
-    "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/dorsal-lab/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz",
-    "download:openvscode-server": "mkdir -p test-resources; cd test-resources; curl -L -o openvscode-server-v1.77.3-linux-x64.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.77.3/openvscode-server-v1.77.3-linux-x64.tar.gz; tar -xf openvscode-server-v1.77.3-linux-x64.tar.gz",
-    "configure:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; sed -i 's;\"$@\".*$;\"$@\" --without-connection-token --install-extension $ROOT/../../vscode-trace-extension/vscode-trace-extension-*.vsix --default-folder=$ROOT/../../TraceCompassTutorialTraces --start-server;g' openvscode-server",
-    "start:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; ./openvscode-server ${0}",
-    "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
-    "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review"
-  },
-  "devDependencies": {
-    "@eclipse-dash/nodejs-wrapper": "^0.0.1",
-    "copy-webpack-plugin": "^11.0.0",
-    "eslint-config-prettier": "^9.0.0",
-    "lerna": "^7.0.0",
-    "ovsx": "^0.9.0",
-    "prettier": "^3.0.2"
-  },
-  "workspaces": [
-    "vscode-trace-common",
-    "vscode-trace-webviews",
-    "vscode-trace-extension"
-  ]
+    "private": true,
+    "scripts": {
+        "prepare": "lerna run prepare",
+        "watch": "lerna exec --stream --parallel -- \"yarn run watch\"",
+        "clean": "lerna run clean",
+        "vsce:package": "lerna run vsce:package",
+        "lint": "lerna run lint",
+        "format:write": "lerna run format:write",
+        "format:check": "lerna run format:check",
+        "download:server": "curl -o trace-compass-server.tar.gz https://download.eclipse.org/tracecompass.incubator/trace-server/rcp/trace-compass-server-latest-linux.gtk.x86_64.tar.gz; tar -xf trace-compass-server.tar.gz",
+        "start:server": "./trace-compass-server/tracecompass-server",
+        "download:sample-traces": "curl -o TraceCompassTutorialTraces.tgz https://raw.githubusercontent.com/dorsal-lab/tracevizlab/master/labs/TraceCompassTutorialTraces.tgz; tar -xf TraceCompassTutorialTraces.tgz",
+        "download:openvscode-server": "mkdir -p test-resources; cd test-resources; curl -L -o openvscode-server-v1.77.3-linux-x64.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.77.3/openvscode-server-v1.77.3-linux-x64.tar.gz; tar -xf openvscode-server-v1.77.3-linux-x64.tar.gz",
+        "configure:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; sed -i 's;\"$@\".*$;\"$@\" --without-connection-token --install-extension $ROOT/../../vscode-trace-extension/vscode-trace-extension-*.vsix --default-folder=$ROOT/../../TraceCompassTutorialTraces --start-server;g' openvscode-server",
+        "start:openvscode-server": "cd test-resources/openvscode-server-v1.77.3-linux-x64/bin/; ./openvscode-server ${0}",
+        "version:major": "lerna version major --exact --no-push --git-tag-command /usr/bin/true --yes -m \"Release %s (Major)\"",
+        "version:minor": "lerna version minor --exact --no-push --git-tag-command /usr/bin/true --yes -m \"Release %s (Minor)\"",
+        "version:patch": "lerna version patch --exact --no-push --git-tag-command /usr/bin/true --yes -m \"Release %s (Patch)\"",
+        "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
+        "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review"
+    },
+    "devDependencies": {
+        "@eclipse-dash/nodejs-wrapper": "^0.0.1",
+        "copy-webpack-plugin": "^11.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "lerna": "^7.0.0",
+        "ovsx": "^0.9.0",
+        "prettier": "^3.0.2"
+    },
+    "workspaces": [
+        "vscode-trace-common",
+        "vscode-trace-webviews",
+        "vscode-trace-extension"
+    ]
 }

--- a/vscode-trace-common/package.json
+++ b/vscode-trace-common/package.json
@@ -1,42 +1,41 @@
 {
     "name": "vscode-trace-common",
     "private": "true",
-    "version": "0.0.0",
+    "version": "0.2.5",
     "categories": [
-      "Other"
+        "Other"
     ],
     "repository": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/",
     "main": "lib",
     "files": [
-      "lib",
-      "src"
+        "lib",
+        "src"
     ],
     "dependencies": {
-      "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
-      "traceviewer-base": "^0.2.1",
-      "tsp-typescript-client": "^0.4.1"
+        "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
+        "traceviewer-base": "^0.2.1",
+        "tsp-typescript-client": "^0.4.1"
     },
     "devDependencies": {
-      "@types/jest": "^23.3.13",
-      "@types/json-bigint": "^1.0.1",
-      "@types/node": "^10.1.2",
-      "@typescript-eslint/eslint-plugin": "^6.0.0",
-      "@typescript-eslint/parser": "^6.0.0",
-      "typescript": "^4.1.3",
-      "eslint": "^8.43.0",
-      "eslint-plugin-import": "^2.21.2",
-      "eslint-plugin-no-null": "^1.0.2",
-      "eslint-plugin-react": "^7.20.0"
+        "@types/jest": "^23.3.13",
+        "@types/json-bigint": "^1.0.1",
+        "@types/node": "^10.1.2",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "eslint": "^8.43.0",
+        "eslint-plugin-import": "^2.21.2",
+        "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-react": "^7.20.0",
+        "typescript": "^4.1.3"
     },
     "scripts": {
-      "prepare": "yarn run clean && yarn run build",
-      "build": "tsc -p tsconfig.json",
-      "clean": "rimraf lib *.tsbuildinfo",
-      "lint": "eslint .",
-      "test": "echo 'test'",
-      "watch": "tsc -w",
-      "format:write": "prettier --write ./src",
-      "format:check": "prettier --check ./src"
+        "prepare": "yarn run clean && yarn run build",
+        "build": "tsc -p tsconfig.json",
+        "clean": "rimraf lib *.tsbuildinfo",
+        "lint": "eslint .",
+        "test": "echo 'test'",
+        "watch": "tsc -w",
+        "format:write": "prettier --write ./src",
+        "format:check": "prettier --check ./src"
     }
-  }
-  
+}

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -1,344 +1,344 @@
 {
-  "name": "vscode-trace-extension",
-  "displayName": "Trace Viewer for VSCode",
-  "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
-  "version": "0.2.5",
-  "license": "MIT",
-  "engines": {
-    "vscode": "^1.52.0"
-  },
-  "publisher": "eclipse-cdt",
-  "icon": "images/extension-icon.png",
-  "categories": [
-    "Visualization",
-    "Data Science",
-    "Other"
-  ],
-  "keywords": [
-    "Trace Compass",
-    "trace",
-    "visualization",
-    "Eclipse Foundation"
-  ],
-  "repository": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/",
-  "bugs": {
-    "url": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/issues"
-  },
-  "activationEvents": [
-    "onStartupFinished"
-  ],
-  "main": "lib/extension",
-  "files": [
-    "lib",
-    "pack"
-  ],
-  "contributes": {
-    "commands": [
-      {
-        "command": "outputs.reset",
-        "title": "Reset",
-        "icon": {
-          "light": "assets/media/house-chimney-light.svg",
-          "dark": "assets/media/house-chimney.svg"
-        }
-      },
-      {
-        "command": "outputs.openOverview",
-        "title": "Show trace overview",
-        "icon": "$(graph-line)"
-      },
-      {
-        "command": "outputs.undo",
-        "title": "Undo",
-        "icon": {
-          "light": "assets/media/arrow-rotate-left-light.svg",
-          "dark": "assets/media/arrow-rotate-left.svg"
-        }
-      },
-      {
-        "command": "outputs.redo",
-        "title": "Redo",
-        "icon": {
-          "light": "assets/media/arrow-rotate-right-light.svg",
-          "dark": "assets/media/arrow-rotate-right.svg"
-        }
-      },
-      {
-        "command": "outputs.zoomIn",
-        "title": "Zoom In",
-        "icon": {
-          "light": "assets/media/square-plus-light.svg",
-          "dark": "assets/media/square-plus.svg"
-        }
-      },
-      {
-        "command": "outputs.zoomOut",
-        "title": "Zoom Out",
-        "icon": {
-          "light": "assets/media/square-minus-light.svg",
-          "dark": "assets/media/square-minus.svg"
-        }
-      },
-      {
-        "command": "traces.openTraceFile",
-        "title": "Open with Trace Viewer",
-        "icon": "assets/media/dep.svg"
-      },
-      {
-        "command": "openedTraces.openTrace",
-        "title": "Open Trace",
-        "icon": "$(new-folder)"
-      },
-      {
-        "command": "trace-explorer.refreshContext",
-        "title": "Refresh Trace Explorer",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "traceViewer.shortcuts",
-        "title": "Trace Viewer Keyboard and Mouse Shortcuts",
-        "icon": "$(info)"
-      },
-      {
-        "command": "serverStatus.started",
-        "title": "Trace Server: started"
-      },
-      {
-        "command": "serverStatus.stopped",
-        "title": "Trace Server: stopped"
-      },
-      {
-        "command": "trace.viewer.toolbar.markersets",
-        "title": "Marker Sets",
-        "icon": "$(three-bars)"
-      },
-      {
-        "command": "trace.viewer.toolbar.filter",
-        "title": "Markers filter",
-        "icon": "$(filter-filled)"
-      }
+    "name": "vscode-trace-extension",
+    "displayName": "Trace Viewer for VSCode",
+    "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
+    "version": "0.2.5",
+    "license": "MIT",
+    "engines": {
+        "vscode": "^1.52.0"
+    },
+    "publisher": "eclipse-cdt",
+    "icon": "images/extension-icon.png",
+    "categories": [
+        "Visualization",
+        "Data Science",
+        "Other"
     ],
-    "viewsContainers": {
-      "activitybar": [
-        {
-          "id": "trace-explorer",
-          "title": "Trace Viewer",
-          "icon": "assets/media/chart-line-solid.svg"
-        }
-      ]
-    },
-    "views": {
-      "trace-explorer": [
-        {
-          "type": "tree",
-          "name": "Welcome",
-          "id": "welcome",
-          "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
-        },
-        {
-          "type": "webview",
-          "id": "traceExplorer.openedTracesView",
-          "name": "Opened Traces",
-          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
-        },
-        {
-          "type": "webview",
-          "id": "traceExplorer.availableViews",
-          "name": "Views",
-          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
-        },
-        {
-          "type": "webview",
-          "id": "traceExplorer.timeRangeDataView",
-          "name": "Time Range Data",
-          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
-        },
-        {
-          "type": "webview",
-          "id": "traceExplorer.itemPropertiesView",
-          "name": "Item Properties",
-          "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
-        }
-      ]
-    },
-    "viewsWelcome": [
-      {
-        "view": "welcome",
-        "name": "Open Trace",
-        "contents": "There are currently no opened traces.\n[Open Trace](command:openedTraces.openTrace)",
-        "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
-      },
-      {
-        "view": "welcome",
-        "name": "Documentation",
-        "contents": "To learn more about how to use the Trace Viewer [read our documentation](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/vscode-trace-extension/README.md).",
-        "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
-      }
+    "keywords": [
+        "Trace Compass",
+        "trace",
+        "visualization",
+        "Eclipse Foundation"
     ],
-    "menus": {
-      "view/title": [
-        {
-          "command": "openedTraces.openTrace",
-          "when": "view == traceExplorer.openedTracesView && !trace-explorer.noExperiments",
-          "group": "navigation"
-        },
-        {
-          "command": "trace-explorer.refreshContext",
-          "when": "view == welcome || view == traceExplorer.openedTracesView",
-          "group": "navigation"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "traces.openTraceFile",
-          "group": "navigation"
-        }
-      ],
-      "editor/title": [
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "outputs.undo",
-          "group": "navigation@1"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "outputs.redo",
-          "group": "navigation@2"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "outputs.zoomIn",
-          "group": "navigation@3"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "outputs.zoomOut",
-          "group": "navigation@4"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "outputs.reset",
-          "group": "navigation@5"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react' && traceViewer.markerCategoriesPresent",
-          "command": "trace.viewer.toolbar.filter",
-          "group": "navigation@6"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react' && traceViewer.markerSetsPresent",
-          "command": "trace.viewer.toolbar.markersets",
-          "group": "navigation@7"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "outputs.openOverview",
-          "group": "navigation@8"
-        },
-        {
-          "when": "activeWebviewPanelId == 'react'",
-          "command": "traceViewer.shortcuts",
-          "group": "navigation@9"
-        }
-      ],
-      "commandPalette": [
-        {
-          "command": "serverStatus.started",
-          "when": "false"
-        },
-        {
-          "command": "serverStatus.stopped",
-          "when": "false"
-        }
-      ]
+    "repository": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/",
+    "bugs": {
+        "url": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/issues"
     },
-    "configuration": {
-      "title": "Trace Compass",
-      "properties": {
-        "trace-compass.traceserver.url": {
-          "type": "string",
-          "default": "http://localhost:8080",
-          "description": "Enter the trace server's URL, including port. Eg: http://localhost:8080."
+    "activationEvents": [
+        "onStartupFinished"
+    ],
+    "main": "lib/extension",
+    "files": [
+        "lib",
+        "pack"
+    ],
+    "contributes": {
+        "commands": [
+            {
+                "command": "outputs.reset",
+                "title": "Reset",
+                "icon": {
+                    "light": "assets/media/house-chimney-light.svg",
+                    "dark": "assets/media/house-chimney.svg"
+                }
+            },
+            {
+                "command": "outputs.openOverview",
+                "title": "Show trace overview",
+                "icon": "$(graph-line)"
+            },
+            {
+                "command": "outputs.undo",
+                "title": "Undo",
+                "icon": {
+                    "light": "assets/media/arrow-rotate-left-light.svg",
+                    "dark": "assets/media/arrow-rotate-left.svg"
+                }
+            },
+            {
+                "command": "outputs.redo",
+                "title": "Redo",
+                "icon": {
+                    "light": "assets/media/arrow-rotate-right-light.svg",
+                    "dark": "assets/media/arrow-rotate-right.svg"
+                }
+            },
+            {
+                "command": "outputs.zoomIn",
+                "title": "Zoom In",
+                "icon": {
+                    "light": "assets/media/square-plus-light.svg",
+                    "dark": "assets/media/square-plus.svg"
+                }
+            },
+            {
+                "command": "outputs.zoomOut",
+                "title": "Zoom Out",
+                "icon": {
+                    "light": "assets/media/square-minus-light.svg",
+                    "dark": "assets/media/square-minus.svg"
+                }
+            },
+            {
+                "command": "traces.openTraceFile",
+                "title": "Open with Trace Viewer",
+                "icon": "assets/media/dep.svg"
+            },
+            {
+                "command": "openedTraces.openTrace",
+                "title": "Open Trace",
+                "icon": "$(new-folder)"
+            },
+            {
+                "command": "trace-explorer.refreshContext",
+                "title": "Refresh Trace Explorer",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "traceViewer.shortcuts",
+                "title": "Trace Viewer Keyboard and Mouse Shortcuts",
+                "icon": "$(info)"
+            },
+            {
+                "command": "serverStatus.started",
+                "title": "Trace Server: started"
+            },
+            {
+                "command": "serverStatus.stopped",
+                "title": "Trace Server: stopped"
+            },
+            {
+                "command": "trace.viewer.toolbar.markersets",
+                "title": "Marker Sets",
+                "icon": "$(three-bars)"
+            },
+            {
+                "command": "trace.viewer.toolbar.filter",
+                "title": "Markers filter",
+                "icon": "$(filter-filled)"
+            }
+        ],
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "trace-explorer",
+                    "title": "Trace Viewer",
+                    "icon": "assets/media/chart-line-solid.svg"
+                }
+            ]
         },
-        "trace-compass.traceserver.apiPath": {
-          "type": "string",
-          "default": "tsp/api",
-          "description": "Enter the trace server's API path, to be appended to the server URL. Eg: 'tsp/api'."
-        }
-      }
+        "views": {
+            "trace-explorer": [
+                {
+                    "type": "tree",
+                    "name": "Welcome",
+                    "id": "welcome",
+                    "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
+                },
+                {
+                    "type": "webview",
+                    "id": "traceExplorer.openedTracesView",
+                    "name": "Opened Traces",
+                    "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
+                },
+                {
+                    "type": "webview",
+                    "id": "traceExplorer.availableViews",
+                    "name": "Views",
+                    "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
+                },
+                {
+                    "type": "webview",
+                    "id": "traceExplorer.timeRangeDataView",
+                    "name": "Time Range Data",
+                    "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
+                },
+                {
+                    "type": "webview",
+                    "id": "traceExplorer.itemPropertiesView",
+                    "name": "Item Properties",
+                    "when": "!trace-explorer.noExperiments && traceViewer.serverUp"
+                }
+            ]
+        },
+        "viewsWelcome": [
+            {
+                "view": "welcome",
+                "name": "Open Trace",
+                "contents": "There are currently no opened traces.\n[Open Trace](command:openedTraces.openTrace)",
+                "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
+            },
+            {
+                "view": "welcome",
+                "name": "Documentation",
+                "contents": "To learn more about how to use the Trace Viewer [read our documentation](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/vscode-trace-extension/README.md).",
+                "when": "trace-explorer.noExperiments || !traceViewer.serverUp"
+            }
+        ],
+        "menus": {
+            "view/title": [
+                {
+                    "command": "openedTraces.openTrace",
+                    "when": "view == traceExplorer.openedTracesView && !trace-explorer.noExperiments",
+                    "group": "navigation"
+                },
+                {
+                    "command": "trace-explorer.refreshContext",
+                    "when": "view == welcome || view == traceExplorer.openedTracesView",
+                    "group": "navigation"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "traces.openTraceFile",
+                    "group": "navigation"
+                }
+            ],
+            "editor/title": [
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "outputs.undo",
+                    "group": "navigation@1"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "outputs.redo",
+                    "group": "navigation@2"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "outputs.zoomIn",
+                    "group": "navigation@3"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "outputs.zoomOut",
+                    "group": "navigation@4"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "outputs.reset",
+                    "group": "navigation@5"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react' && traceViewer.markerCategoriesPresent",
+                    "command": "trace.viewer.toolbar.filter",
+                    "group": "navigation@6"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react' && traceViewer.markerSetsPresent",
+                    "command": "trace.viewer.toolbar.markersets",
+                    "group": "navigation@7"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "outputs.openOverview",
+                    "group": "navigation@8"
+                },
+                {
+                    "when": "activeWebviewPanelId == 'react'",
+                    "command": "traceViewer.shortcuts",
+                    "group": "navigation@9"
+                }
+            ],
+            "commandPalette": [
+                {
+                    "command": "serverStatus.started",
+                    "when": "false"
+                },
+                {
+                    "command": "serverStatus.stopped",
+                    "when": "false"
+                }
+            ]
+        },
+        "configuration": {
+            "title": "Trace Compass",
+            "properties": {
+                "trace-compass.traceserver.url": {
+                    "type": "string",
+                    "default": "http://localhost:8080",
+                    "description": "Enter the trace server's URL, including port. Eg: http://localhost:8080."
+                },
+                "trace-compass.traceserver.apiPath": {
+                    "type": "string",
+                    "default": "tsp/api",
+                    "description": "Enter the trace server's API path, to be appended to the server URL. Eg: 'tsp/api'."
+                }
+            }
+        },
+        "keybindings": [
+            {
+                "command": "traceViewer.shortcuts",
+                "key": "ctrl+f1",
+                "mac": "cmd+f1"
+            }
+        ]
     },
-    "keybindings": [
-      {
-        "command": "traceViewer.shortcuts",
-        "key": "ctrl+f1",
-        "mac": "cmd+f1"
-      }
+    "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
+        "@fortawesome/free-solid-svg-icons": "^5.8.1",
+        "@fortawesome/react-fontawesome": "^0.1.4",
+        "@vscode/codicons": "^0.0.33",
+        "@vscode/vsce": "^2.21.0",
+        "ag-grid-community": "^28.2.0",
+        "ag-grid-react": "^28.2.0",
+        "chart.js": "^2.8.0",
+        "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
+        "lodash": "^4.17.15",
+        "terser": "4.8.1",
+        "traceviewer-base": "^0.2.1",
+        "traceviewer-react-components": "^0.2.1",
+        "vscode-trace-common": "0.2.5"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.32.3",
+        "@types/jest": "^23.3.13",
+        "@types/json-bigint": "^1.0.1",
+        "@types/node": "^10.1.2",
+        "@types/vscode": "^1.52.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "css-loader": "^5.0.1",
+        "eslint": "^8.43.0",
+        "eslint-plugin-import": "^2.21.2",
+        "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-react": "^7.20.0",
+        "rimraf": "^2.6.3",
+        "source-map-loader": "^1.0.2",
+        "style-loader": "^2.0.0",
+        "svg-url-loader": "^7.1.1",
+        "ts-loader": "^8.0.14",
+        "typescript": "^4.1.3"
+    },
+    "resolutions": {
+        "terser": "3.14.1",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0"
+    },
+    "scripts": {
+        "prepare": "yarn run clean && yarn run build && yarn run webpack",
+        "clean": "rimraf lib",
+        "build": "tsc -p tsconfig.json",
+        "webpack": "webpack --mode development",
+        "webpack-dev": "webpack --mode development --watch",
+        "webpack:production": "webpack --mode production",
+        "test": "react-scripts test --env=jsdom",
+        "vscode:prepublish": "yarn prepare && yarn run webpack:production",
+        "vsce:package": "vsce package --yarn",
+        "vsce:ls": "vsce ls --yarn",
+        "tswatch": "tsc -w -p tsconfig.json",
+        "watch": "yarn run webpack-dev",
+        "lint": "eslint .",
+        "format:write": "prettier --write ./src",
+        "format:check": "prettier --check ./src"
+    },
+    "browserslist": [
+        ">0.2%",
+        "not dead",
+        "not ie <= 11",
+        "not op_mini all"
     ]
-  },
-  "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
-    "@fortawesome/free-solid-svg-icons": "^5.8.1",
-    "@fortawesome/react-fontawesome": "^0.1.4",
-    "@vscode/codicons": "^0.0.33",
-    "ag-grid-community": "^28.2.0",
-    "ag-grid-react": "^28.2.0",
-    "chart.js": "^2.8.0",
-    "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
-    "lodash": "^4.17.15",
-    "terser": "4.8.1",
-    "traceviewer-base": "^0.2.1",
-    "traceviewer-react-components": "^0.2.1",
-    "@vscode/vsce": "^2.21.0",
-    "vscode-trace-common": "0.0.0"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.32.3",
-    "@types/jest": "^23.3.13",
-    "@types/json-bigint": "^1.0.1",
-    "@types/node": "^10.1.2",
-    "@types/vscode": "^1.52.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "css-loader": "^5.0.1",
-    "eslint": "^8.43.0",
-    "eslint-plugin-import": "^2.21.2",
-    "eslint-plugin-no-null": "^1.0.2",
-    "eslint-plugin-react": "^7.20.0",
-    "rimraf": "^2.6.3",
-    "source-map-loader": "^1.0.2",
-    "style-loader": "^2.0.0",
-    "svg-url-loader": "^7.1.1",
-    "ts-loader": "^8.0.14",
-    "typescript": "^4.1.3"
-  },
-  "resolutions": {
-    "terser": "3.14.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
-  },
-  "scripts": {
-    "prepare": "yarn run clean && yarn run build && yarn run webpack",
-    "clean": "rimraf lib",
-    "build": "tsc -p tsconfig.json",
-    "webpack": "webpack --mode development",
-    "webpack-dev": "webpack --mode development --watch",
-    "webpack:production": "webpack --mode production",
-    "test": "react-scripts test --env=jsdom",
-    "vscode:prepublish": "yarn prepare && yarn run webpack:production",
-    "vsce:package": "vsce package --yarn",
-    "vsce:ls": "vsce ls --yarn",
-    "tswatch": "tsc -w -p tsconfig.json",
-    "watch": "yarn run webpack-dev",
-    "lint": "eslint .",
-    "format:write": "prettier --write ./src",
-    "format:check": "prettier --check ./src"
-  },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
 }

--- a/vscode-trace-webviews/package.json
+++ b/vscode-trace-webviews/package.json
@@ -1,75 +1,74 @@
 {
-  "name": "vscode-trace-webviews",
-  "private": "true",
-  "version": "0.0.0",
-  "engines": {
-    "vscode": "^1.52.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "repository": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/",
-  "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
-    "@fortawesome/free-solid-svg-icons": "^5.8.1",
-    "@fortawesome/react-fontawesome": "^0.1.4",
-    "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
-    "lodash": "^4.17.15",
-    "lodash.debounce": "^4.0.8",
-    "react": "^18.0.0",
-    "react-chartjs-2": "^2.7.6",
-    "react-dom": "^18.0.0",
-    "react-grid-layout": "^1.1.0",
-    "react-modal": "^3.8.1",
-    "react-virtualized": "^9.21.0",
-    "react-contexify": "^5.0.0",
-    "semantic-ui-css": "^2.4.1",
-    "semantic-ui-react": "^0.86.0",
-    "traceviewer-base": "^0.2.1",
-    "traceviewer-react-components": "^0.2.1",
-    "vscode-trace-common": "0.0.0",
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
-    "@mui/material": "^5.10.14"
+    "name": "vscode-trace-webviews",
+    "private": "true",
+    "version": "0.2.5",
+    "engines": {
+        "vscode": "^1.52.0"
     },
-  "devDependencies": {
-    "@types/jest": "^23.3.13",
-    "@types/json-bigint": "^1.0.1",
-    "@types/node": "^10.1.2",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "css-loader": "^5.0.1",
-    
-    "style-loader": "^2.0.0",
-    "svg-url-loader": "^7.1.1",
-    "ts-loader": "^8.0.14",
-    "typescript": "^4.1.3",
-    "webpack": "^5.20.2",
-    "webpack-cli": "^4.5.0",
-    "eslint": "^8.43.0",
-    "eslint-plugin-import": "^2.21.2",
-    "eslint-plugin-no-null": "^1.0.2",
-    "eslint-plugin-react": "^7.20.0"
-  },
-  "resolutions": {
-    "terser": "3.14.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
-  },
-  "scripts": {
-    "prepare": "yarn run clean && yarn run build && yarn run webpack",
-    "clean": "rimraf lib pack",
-    "build": "tsc -b",
-    "webpack": "webpack --mode development",
-    "vsce:package": "yarn run prepare",
-    "test": "react-scripts test --env=jsdom",
-    "watch": "webpack --watch --mode development",
-    "lint": "eslint .",
-    "format:write": "prettier --write ./src",
-    "format:check": "prettier --check ./src"
-  }
+    "categories": [
+        "Other"
+    ],
+    "repository": "https://github.com/eclipse-cdt-cloud/vscode-trace-extension/",
+    "dependencies": {
+        "@emotion/react": "^11.10.5",
+        "@emotion/styled": "^11.10.5",
+        "@fortawesome/fontawesome-svg-core": "^1.2.17 <1.3.0",
+        "@fortawesome/free-solid-svg-icons": "^5.8.1",
+        "@fortawesome/react-fontawesome": "^0.1.4",
+        "@mui/material": "^5.10.14",
+        "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
+        "lodash": "^4.17.15",
+        "lodash.debounce": "^4.0.8",
+        "react": "^18.0.0",
+        "react-chartjs-2": "^2.7.6",
+        "react-contexify": "^5.0.0",
+        "react-dom": "^18.0.0",
+        "react-grid-layout": "^1.1.0",
+        "react-modal": "^3.8.1",
+        "react-virtualized": "^9.21.0",
+        "semantic-ui-css": "^2.4.1",
+        "semantic-ui-react": "^0.86.0",
+        "traceviewer-base": "^0.2.1",
+        "traceviewer-react-components": "^0.2.1",
+        "vscode-trace-common": "0.2.5"
+    },
+    "devDependencies": {
+        "@types/jest": "^23.3.13",
+        "@types/json-bigint": "^1.0.1",
+        "@types/node": "^10.1.2",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "css-loader": "^5.0.1",
+        "eslint": "^8.43.0",
+        "eslint-plugin-import": "^2.21.2",
+        "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-react": "^7.20.0",
+        "style-loader": "^2.0.0",
+        "svg-url-loader": "^7.1.1",
+        "ts-loader": "^8.0.14",
+        "typescript": "^4.1.3",
+        "webpack": "^5.20.2",
+        "webpack-cli": "^4.5.0"
+    },
+    "resolutions": {
+        "terser": "3.14.1",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0"
+    },
+    "scripts": {
+        "prepare": "yarn run clean && yarn run build && yarn run webpack",
+        "clean": "rimraf lib pack",
+        "build": "tsc -b",
+        "webpack": "webpack --mode development",
+        "vsce:package": "yarn run prepare",
+        "test": "react-scripts test --env=jsdom",
+        "watch": "webpack --watch --mode development",
+        "lint": "eslint .",
+        "format:write": "prettier --write ./src",
+        "format:check": "prettier --check ./src"
+    }
 }


### PR DESCRIPTION
Make this repo more similar to our other cdt-cloud repos:
- prevent triggering release-related jobs on forks
- document release process in root README
- add package.json scripts to help create the release commit and step version

Also, pre-format the various `package.json` and `lerna.json` files, as per lerna expectations. 
- indent using 4 spaces
- ordered dependencies

This is the format lerna enforces. Doing it now means that when we eventually use lerna to step the package.json versions, only the version change will be reflected in the result.

_Note: because of the many indentation-related changes, it might be easier to review using the "hide whitespace" option, in the "files changes" panel._