### PR TITLE
Release v0.2.6

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.5
+tag: v0.2.6
 
 commitInclude:
   parentOfMergeCommit: true

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-trace-extension",
     "displayName": "Trace Viewer for VSCode",
     "description": "Viewer that permits visualizing traces and contained data, analyzed by a trace server, and provided over the Trace Server Protocol (TSP)",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "license": "MIT",
     "engines": {
         "vscode": "^1.52.0"


### PR DESCRIPTION
Publish VSCode Trace Extension version 0.2.6.

Signed-off-by: Neel Gondalia <ngondalia@blackberry.com>