### PR TITLE
Add Disposable of registered tree data provider to context subscription

### DIFF
--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -228,7 +228,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extern
     vscode.commands.executeCommand('trace-explorer.refreshContext');
 
     // Workaround for Theia compatibility of welcome screen. See https://github.com/eclipse-theia/theia/issues/9361
-    vscode.window.registerTreeDataProvider('welcome', new EmptyTreeDataProvider());
+    context.subscriptions.push(vscode.window.registerTreeDataProvider('welcome', new EmptyTreeDataProvider()));
 
     return traceExtensionAPI;
 }


### PR DESCRIPTION
This makes sure that the corresponding treeView is disposed properly.

This was missed in #244 that fixes #242.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>