### PR TITLE
Move 'Open with Trace Viewer' option lower

### DIFF
--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -191,7 +191,7 @@
             "explorer/context": [
                 {
                     "command": "traces.openTraceFile",
-                    "group": "navigation"
+                    "group": "navigation@40"
                 }
             ],
             "editor/title": [


### PR DESCRIPTION
Moves it to a lower / more appropriate part of the context menu.

Before:
![image](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/assets/98342456/75fc7fa0-7746-474e-bd5d-978e9f408c7c)

After:
![image](https://github.com/eclipse-cdt-cloud/vscode-trace-extension/assets/98342456/a848e6b9-f734-4dae-ad7b-38e6c7bb606f)

Signed-off-by: Will Yang <william.yang@ericsson.com>