### PR TITLE
Fix exception in TraceExplorerItemPropertiesProvider

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -40,7 +40,7 @@ export class TraceExplorerItemPropertiesProvider extends AbstractTraceExplorerPr
     }
 
     handleExperimentChanged = (exp: Experiment) => {
-        const props = this.propertiesMap.get(exp.UUID);
+        const props = this.propertiesMap.get(exp?.UUID);
         if (props) {
             this.handleUpdatedProperties(props);
         } else {


### PR DESCRIPTION
The PR fixes the following exception:
TypeError: Cannot read properties of undefined (reading 'UUID') at TraceExplorerItemPropertiesProvider.handleExperimentChanged

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>