### PR TITLE
  Update CSP for all webviews and allow data: for img-src/font-src

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
@@ -90,7 +90,7 @@ export abstract class AbstractTraceExplorerProvider implements vscode.WebviewVie
 				<title>React App</title>
 				<meta http-equiv="Content-Security-Policy"
 					content="default-src 'none';
-					img-src vscode-resource: https:;
+					img-src ${webview.cspSource};
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
 					connect-src ${getTraceServerUrl()};

--- a/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
@@ -92,7 +92,7 @@ export abstract class AbstractTraceExplorerProvider implements vscode.WebviewVie
 					content="default-src 'none';
 					img-src ${webview.cspSource};
 					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
+					style-src ${webview.cspSource} 'unsafe-inline';
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />

--- a/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
@@ -55,7 +55,7 @@ export class KeyboardShortcutsPanel {
 					content="default-src 'none';
 					img-src ${webview.cspSource};
 					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
+					style-src ${webview.cspSource} 'unsafe-inline';
 					connect-src ${getTraceServerUrl()};
                     font-src ${webview.cspSource}">
                 <base href="${packUri}/">

--- a/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
@@ -53,7 +53,7 @@ export class KeyboardShortcutsPanel {
 				<title>React App</title>
 				<meta http-equiv="Content-Security-Policy"
 					content="default-src 'none';
-					img-src vscode-resource: https:;
+					img-src ${webview.cspSource};
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
 					connect-src ${getTraceServerUrl()};

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -527,11 +527,11 @@ export class TraceViewerPanel {
 				<title>React App</title>
 				<meta http-equiv="Content-Security-Policy"
 					content="default-src 'none';
-					img-src vscode-resource: https:;
+					img-src ${webview.cspSource} data:;
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
 					connect-src ${getTraceServerUrl()};
-					font-src ${webview.cspSource}">
+					font-src ${webview.cspSource} data:">
 				<link href="${codiconsUri}" rel="stylesheet" />
 				<base href="${packUri}/">
 			</head>
@@ -565,11 +565,11 @@ export class TraceViewerPanel {
 				<title>React App</title>
 				<meta http-equiv="Content-Security-Policy"
 					content="default-src 'none';
-					img-src vscode-resource: https:;
+					img-src ${webview.cspSource} data:;
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
 					connect-src ${getTraceServerUrl()};
-					font-src ${webview.cspSource}">
+					font-src ${webview.cspSource} data:">
 				<link href="${codiconsUri}" rel="stylesheet" />
 				<base href="${packUri}/">
 			</head>

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -529,7 +529,7 @@ export class TraceViewerPanel {
 					content="default-src 'none';
 					img-src ${webview.cspSource} data:;
 					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
+					style-src ${webview.cspSource} 'unsafe-inline';
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource} data:">
 				<link href="${codiconsUri}" rel="stylesheet" />
@@ -567,7 +567,7 @@ export class TraceViewerPanel {
 					content="default-src 'none';
 					img-src ${webview.cspSource} data:;
 					script-src 'nonce-${nonce}' 'unsafe-eval';
-					style-src ${webview.cspSource} vscode-resource: 'unsafe-inline' http: https: data:;
+					style-src ${webview.cspSource} 'unsafe-inline';
 					connect-src ${getTraceServerUrl()};
 					font-src ${webview.cspSource} data:">
 				<link href="${codiconsUri}" rel="stylesheet" />


### PR DESCRIPTION
- Update CSP for all webviews and allow data: for img-src/font-src
Fixes #251
- Remove vscode-resource/http/https/data from style-src for all webviews

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>