### PR TITLE
Fix issue #265

### DIFF
--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -67,7 +67,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extern
         vscode.commands.registerCommand('traces.openTraceFile', async (file: vscode.Uri) => {
             await startTraceServerIfAvailable(file.fsPath);
             if (await isTraceServerUp()) {
-                fileOpenHandler(context, file);
+                await fileOpenHandler(context, file);
                 vscode.commands.executeCommand('trace-explorer.refreshContext');
             }
         })

--- a/vscode-trace-extension/src/trace-explorer/trace-utils.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-utils.ts
@@ -55,7 +55,7 @@ export const fileHandler =
     async (context: vscode.ExtensionContext, traceUri: vscode.Uri): Promise<void> => {
         const resolvedTraceURI: vscode.Uri = traceUri;
         const { traceManager, experimentManager } = getManagers();
-        vscode.window.withProgress(
+        return vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
                 title: getProgressBarTitle(resolvedTraceURI),


### PR DESCRIPTION
Wait for fileOpenHandler to finish, before refreshing the trace explorer context.