### PR TITLE
Update to latest traceviewer-* dependencies

### DIFF
--- a/vscode-trace-common/package.json
+++ b/vscode-trace-common/package.json
@@ -13,8 +13,8 @@
     ],
     "dependencies": {
         "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
-        "traceviewer-base": "^0.2.6",
-        "tsp-typescript-client": "^0.4.2"
+        "traceviewer-base": "^0.2.7",
+        "tsp-typescript-client": "^0.4.3"
     },
     "devDependencies": {
         "@types/jest": "^23.3.13",

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -287,8 +287,8 @@
         "json-bigint": "sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473",
         "lodash": "^4.17.15",
         "terser": "4.8.1",
-        "traceviewer-base": "^0.2.6",
-        "traceviewer-react-components": "^0.2.6",
+        "traceviewer-base": "^0.2.7",
+        "traceviewer-react-components": "^0.2.7",
         "vscode-trace-common": "0.2.8"
     },
     "devDependencies": {

--- a/vscode-trace-webviews/package.json
+++ b/vscode-trace-webviews/package.json
@@ -28,8 +28,8 @@
         "react-virtualized": "^9.21.0",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^0.86.0",
-        "traceviewer-base": "^0.2.6",
-        "traceviewer-react-components": "^0.2.6",
+        "traceviewer-base": "^0.2.7",
+        "traceviewer-react-components": "^0.2.7",
         "vscode-trace-common": "0.2.8"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7639,10 +7639,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-timeline-chart@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/timeline-chart/-/timeline-chart-0.3.2.tgz#a943e613c3d211ee81e7225c8d9c1654ac858555"
-  integrity sha512-DnmD2c+N4IGx5/AOxacUu2r9FanxAtbfratUxiElkYS53vZ65DBjiOTPvarsGeIC+DZNnVjObcq4jyh/tshFbg==
+timeline-chart@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.npmjs.org/timeline-chart/-/timeline-chart-0.3.4.tgz#2833ac5c1250ae1273bc8287b989af350b373792"
+  integrity sha512-npz+x1/b11DzNAmh3FBS3QGLuUbvmOioZ9CSEi2e/97vo046ds1Y1wHR6vvmnhqVMmKSf0/TueQB6F8NhmhCdg==
   dependencies:
     "@types/lodash.throttle" "^4.1.4"
     glob "^7.1.6"
@@ -7679,17 +7679,17 @@ tr46@~0.0.3:
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-traceviewer-base@0.2.6, traceviewer-base@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/traceviewer-base/-/traceviewer-base-0.2.6.tgz#6c2cde6ec269578c46cdfd635ac52cefc32983ff"
-  integrity sha512-yY9t2l8STPZR44oXqA6rVhTFHb59Wprj8lPrxjz7Aw0+syE34fzktaO+equKtOmczJByBFE+Cf1vyD4+CFy92A==
+traceviewer-base@0.2.7, traceviewer-base@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.npmjs.org/traceviewer-base/-/traceviewer-base-0.2.7.tgz#236b1be27df31309fdd377ef347c2de492f7cbda"
+  integrity sha512-26tyH2JQQGos0OOQEx37rJisro++sakhDmokjMgTzQkhhoJbgGVQh0CKyibbHWENzf80ZI+CxfLH5NpMq/6hkg==
   dependencies:
-    tsp-typescript-client "^0.4.2"
+    tsp-typescript-client "^0.4.3"
 
-traceviewer-react-components@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.npmjs.org/traceviewer-react-components/-/traceviewer-react-components-0.2.6.tgz#98269d4139f4fd4619424f835c2b00998e69e064"
-  integrity sha512-kcwzC3HKZyniz3zTZZI/EHMi8KPGBrI5bQ6L7+4iYrQpyZsEktORS3r2o8ovLMPGZhTP+NktEyQMcEAiMSUWOQ==
+traceviewer-react-components@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.npmjs.org/traceviewer-react-components/-/traceviewer-react-components-0.2.7.tgz#09f5b6732227c93b8293ca80f0b0b5de382ea3b3"
+  integrity sha512-pFRFjMd0S+Qaf2Fx0I6GwtoXrRnIiDoPjbrbE+ZqvL/+pQEMoEr15k9VAN5ghErAgjgGH8sPjL6E5UgU2Diq3A==
   dependencies:
     "@ag-grid-community/core" "^32.0.1"
     "@ag-grid-community/infinite-row-model" "^32.0.0"
@@ -7711,9 +7711,9 @@ traceviewer-react-components@^0.2.6:
     react-virtualized "^9.21.0"
     semantic-ui-css "^2.4.1"
     semantic-ui-react "^0.86.0"
-    timeline-chart "^0.3.2"
-    traceviewer-base "0.2.6"
-    tsp-typescript-client "^0.4.2"
+    timeline-chart "^0.3.4"
+    traceviewer-base "0.2.7"
+    tsp-typescript-client "^0.4.3"
 
 trim-newlines@^3.0.0:
   version "3.0.1"
@@ -7760,10 +7760,10 @@ tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-tsp-typescript-client@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.npmjs.org/tsp-typescript-client/-/tsp-typescript-client-0.4.2.tgz#1c4d1328a26a90148f34ddbdf5525f4edd923732"
-  integrity sha512-MPYA9DctzwpMdcEIaZGQUKonHY+zGBB6yKnaTZlheBGlPV16N0nSHvuYTAhZ3K8yWgKilzZ+Bsx6gyFFtjM3EA==
+tsp-typescript-client@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/tsp-typescript-client/-/tsp-typescript-client-0.4.3.tgz#c2a679c8bed359ff09f4532d0365e0ee42dae461"
+  integrity sha512-6wmi9Y6ftWJHWdNmzt7b5ST2EPP3srDnPfviA/8hSt/VYsFnagDKLCWWuCHVSPee2XmEWG2vfIIy3Q6LzJdHiQ==
   dependencies:
     json-bigint sidorares/json-bigint#2c0a5f896d7888e68e5f4ae3c7ea5cd42fd54473
     node-fetch "^2.5.0"


### PR DESCRIPTION
We recently published updated version of "traceviewer-react-components" and "traceviewer-base", which themselves use updated versions of "timeline-chart" and "tsp-typescript-client". This commit updates the version range of related dependencies, requested in this repo, so that the latest versions are picked-up.