### PR TITLE
remove trailing commas from tsconfig.json file instances

### DIFF
--- a/vscode-trace-common/tsconfig.json
+++ b/vscode-trace-common/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "../common-tsconfig.json",
 	"compilerOptions": {
         "rootDir": "src",
-        "outDir": "lib",
+        "outDir": "lib"
     },
     "include": [
         "src"

--- a/vscode-trace-extension/tsconfig.json
+++ b/vscode-trace-extension/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../common-tsconfig.json",
     "compilerOptions": {
         "rootDir": "src",
-        "outDir": "lib",
+        "outDir": "lib"
     },
     "include": [
         "src"

--- a/vscode-trace-webviews/tsconfig.json
+++ b/vscode-trace-webviews/tsconfig.json
@@ -2,7 +2,7 @@
 	"extends": "../common-tsconfig.json",
 	"compilerOptions": {
         "rootDir": "src",
-        "outDir": "lib",
+        "outDir": "lib"
     },
     "include": [
         "src"


### PR DESCRIPTION
The presence of trailing commas within tsconfig.json files doesn't seem to adversely affect the normal build process of vscode-trace-extension, but it seems to lead to build-time problems if you try to incorporate vscode-trace-extension into a monorepo for building a Theia-based product.  For example, this is an example snippet when running "yarn" from top-level of such a monorepo of Theia-based product:

$ yarn -s compile:references && lerna run prepare && yarn -s compile
ParseError in file: /home/build/git/theia-based-product/vscode-extensions/vscode-trace-extension/vscode-trace-common/tsconfig.json
SyntaxError: Expected double-quoted property name in JSON at position 118
    at JSON.parse (<anonymous>)
    at readJsonFile (/home/build/git/theia-based-product/scripts/compile-references.js:147:21)
    at async configureTypeScriptReferences (/home/build/git/theia-based-product/scripts/compile-references.js:109:26)
    at async /home/build/git/theia-based-product/scripts/compile-references.js:74:9
    at async Promise.all (index 71)
    at async compileTypeScriptReferences (/home/build/git/theia-based-product/scripts/compile-references.js:72:5)

Avoiding the trailing commas in tsconfig.json files seems to avoid that sort of build-time problem when vscode-trace-extension is treated as a (buildable from source) sub-project within a monorepo of a Theia-based project.