### PR TITLE
Select experiment when opening from open command

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -390,7 +390,7 @@ export class TraceViewerPanel {
         const wrapper: string = JSONBig.stringify(experiment);
         this._panel.webview.postMessage({ command: VSCODE_MESSAGES.SET_EXPERIMENT, data: wrapper });
         signalManager().fireExperimentOpenedSignal(experiment);
-        // No need to send activatedSignal because it will be triggered when the panal becomes active
+        signalManager().fireTraceViewerTabActivatedSignal(experiment);
     }
 
     addOutput(descriptor: OutputDescriptor): void {


### PR DESCRIPTION
Send TRACEVIEWERTAB_ACTIVATED signal when setting the experiment after a experiment is opened. This will select the experiment in the opened traces view which then will broadcast the EXPERIMENT_SELECTED signal to update other webviews.

Fixes #264

![fix-selection-after-open](https://github.com/user-attachments/assets/2980991c-6503-4cb8-9e52-e9abb11608c6)


Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>