### PR TITLE
Implement source lookup in Item Properties view

### DIFF
--- a/vscode-trace-common/src/messages/vscode-message-manager.ts
+++ b/vscode-trace-common/src/messages/vscode-message-manager.ts
@@ -74,7 +74,7 @@ export const VSCODE_MESSAGES = {
     OUTPUT_DATA_CHANGED: 'outputDataChanged',
     CONTRIBUTE_CONTEXT_MENU: 'contributeContextMenu',
     CONTEXT_MENU_ITEM_CLICKED: 'contextMenuItemClicked',
-    GO_TO_SOURCE_FILE: 'goToSourceFile'
+    SOURCE_LOOKUP: 'sourceLookup'
 };
 
 export class VsCodeMessageManager extends Messages.MessageManager {
@@ -211,8 +211,8 @@ export class VsCodeMessageManager extends Messages.MessageManager {
         vscode.postMessage({ command: VSCODE_MESSAGES.CONTEXT_MENU_ITEM_CLICKED, data: data });
     }
 
-    goToSourceFile(path : string, line : number): void {
+    sourceLookup(path : string, line : number): void {
         const data = {path : path, line : line};
-        vscode.postMessage({ command: VSCODE_MESSAGES.GO_TO_SOURCE_FILE, data: data });	
+        vscode.postMessage({ command: VSCODE_MESSAGES.SOURCE_LOOKUP, data: data });	
     }
 }

--- a/vscode-trace-common/src/messages/vscode-message-manager.ts
+++ b/vscode-trace-common/src/messages/vscode-message-manager.ts
@@ -211,8 +211,8 @@ export class VsCodeMessageManager extends Messages.MessageManager {
         vscode.postMessage({ command: VSCODE_MESSAGES.CONTEXT_MENU_ITEM_CLICKED, data: data });
     }
 
-    sourceLookup(path : string, line : number): void {
-        const data = {path : path, line : line};
-        vscode.postMessage({ command: VSCODE_MESSAGES.SOURCE_LOOKUP, data: data });	
+    sourceLookup(path: string, line: number): void {
+        const data = { path: path, line: line };
+        vscode.postMessage({ command: VSCODE_MESSAGES.SOURCE_LOOKUP, data: data });
     }
 }

--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -34,30 +34,27 @@ export class TraceExplorerItemPropertiesProvider extends AbstractTraceExplorerPr
             }
         });
 
-        this._view?.webview?.onDidReceiveMessage(
-            (message) => {
-                const command = message.command;
-                const data = message.data;
-                switch (command) {
-                    case VSCODE_MESSAGES.SOURCE_LOOKUP:
-                        // open an editor window with the file contents,
-                        // reveal the line and position the cursor at the beginning of the line
-                        const path : string = data.path;
-                        vscode.workspace.openTextDocument(path).then(
-                            (doc) => vscode.window.showTextDocument(doc)
-                        ).then(
-                            (editor) => {
-                                const zeroBasedLine = data.line-1;
-                                const range = new vscode.Range(zeroBasedLine, 0, zeroBasedLine, 0);
-                                editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
-                                const selection = new vscode.Selection(zeroBasedLine, 0, zeroBasedLine, 0);
-                                editor.selection = selection;
-                            }
-                        );
-                        break;
-                }
+        this._view?.webview?.onDidReceiveMessage(message => {
+            const command = message.command;
+            const data = message.data;
+            switch (command) {
+                case VSCODE_MESSAGES.SOURCE_LOOKUP:
+                    // open an editor window with the file contents,
+                    // reveal the line and position the cursor at the beginning of the line
+                    const path: string = data.path;
+                    vscode.workspace
+                        .openTextDocument(path)
+                        .then(doc => vscode.window.showTextDocument(doc))
+                        .then(editor => {
+                            const zeroBasedLine = data.line - 1;
+                            const range = new vscode.Range(zeroBasedLine, 0, zeroBasedLine, 0);
+                            editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
+                            const selection = new vscode.Selection(zeroBasedLine, 0, zeroBasedLine, 0);
+                            editor.selection = selection;
+                        });
+                    break;
             }
-        );
+        });
 
         signalManager().on(Signals.ITEM_PROPERTIES_UPDATED, this.handleUpdatedProperties);
         signalManager().on(Signals.EXPERIMENT_SELECTED, this.handleExperimentChanged);

--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -39,7 +39,7 @@ export class TraceExplorerItemPropertiesProvider extends AbstractTraceExplorerPr
                 const command = message.command;
                 const data = message.data;
                 switch (command) {
-                    case VSCODE_MESSAGES.GO_TO_SOURCE_FILE:
+                    case VSCODE_MESSAGES.SOURCE_LOOKUP:
                         // open an editor window with the file contents,
                         // reveal the line and position the cursor at the beginning of the line
                         const path : string = data.path;

--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -40,10 +40,18 @@ export class TraceExplorerItemPropertiesProvider extends AbstractTraceExplorerPr
                 const data = message.data;
                 switch (command) {
                     case VSCODE_MESSAGES.GO_TO_SOURCE_FILE:
+                        // open an editor window with the file contents,
+                        // reveal the line and position the cursor at the beginning of the line
                         const path : string = data.path;
                         vscode.workspace.openTextDocument(path).then(
-                            (doc) => {
-                                vscode.window.showTextDocument(doc);
+                            (doc) => vscode.window.showTextDocument(doc)
+                        ).then(
+                            (editor) => {
+                                const zeroBasedLine = data.line-1;
+                                const range = new vscode.Range(zeroBasedLine, 0, zeroBasedLine, 0);
+                                editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
+                                const selection = new vscode.Selection(zeroBasedLine, 0, zeroBasedLine, 0);
+                                editor.selection = selection;
                             }
                         );
                         break;

--- a/vscode-trace-webviews/src/trace-explorer/properties/vscode-trace-explorer-properties-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/properties/vscode-trace-explorer-properties-widget.tsx
@@ -6,6 +6,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import React from 'react';
 import '../../style/trace-viewer.css';
+import 'traceviewer-react-components/style/trace-explorer.css';
 import { VSCODE_MESSAGES, VsCodeMessageManager } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { ReactItemPropertiesWidget } from 'traceviewer-react-components/lib/trace-explorer/trace-explorer-properties-widget';
 import { signalManager } from 'traceviewer-base/lib/signals/signal-manager';
@@ -67,7 +68,6 @@ class TraceExplorerProperties extends React.Component<{}, PropertiesViewState> {
         const { fileLocation, line }: { fileLocation: string; line: string } = JSON.parse(
             `${e.currentTarget.getAttribute('data-id')}`
         );
-        console.log('filename: ' + fileLocation + ':' + line);
         this._signalHandler.sourceLookup(fileLocation, +line);
     }
 }

--- a/vscode-trace-webviews/src/trace-explorer/properties/vscode-trace-explorer-properties-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/properties/vscode-trace-explorer-properties-widget.tsx
@@ -67,9 +67,8 @@ class TraceExplorerProperties extends React.Component<{}, PropertiesViewState> {
         const { fileLocation, line }: { fileLocation: string; line: string } = JSON.parse(
             `${e.currentTarget.getAttribute('data-id')}`
         );
-        // console.log('filename: ' + fileLocation + ':' + line);
-        // console.log('Source lookup method not implemented');
-        this._signalHandler.goToSourceFile(fileLocation, +line);
+        console.log('filename: ' + fileLocation + ':' + line);
+        this._signalHandler.sourceLookup(fileLocation, +line);
     }
 }
 


### PR DESCRIPTION
The intention of this patch is to achieve the following runtime behavior:

If a loaded trace has a "Source" column, and if the value of that column is of the form file:line, then highlighting the event in question, and clicking on the "Source" value that shows up in Item Properties shall open the corresponding file in a VSCode editor, and position the cursor on the corresponding line number, if said file exists.