### PR TITLE
Support of directory traces other than CTF

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/trace-utils.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-utils.ts
@@ -86,6 +86,12 @@ export const fileHandler =
                     if (fileStat.type === vscode.FileType.Directory) {
                         // Find recursively CTF traces
                         const foundTraces = await findTraces(filePath);
+
+                        // No CTF traces found. Add root directory as trace directory.
+                        // Back-end will reject if it is not a trace
+                        if (foundTraces.length === 0) {
+                            foundTraces.push(filePath);
+                        }
                         foundTraces.forEach(trace => tracesArray.push(trace));
                     } else {
                         // Open single trace file


### PR DESCRIPTION
The trace detection algorithm checks recursively for CTF traces. If no CTF trace are found under the root directory, then use the root directory as trace directory. The trace server back-end will validate if this path points to a valid trace or not.

With this it's now possible to open traces that are directories other than CTF.

Note that only a single trace can be opened in the experiment and not set of traces, which is currently only supported with CTF traces.

Examples trace type: uftrace

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>