### PR TITLE
Update 'noExperiments' context after trace open

### DIFF
--- a/vscode-trace-extension/src/trace-explorer/trace-utils.ts
+++ b/vscode-trace-extension/src/trace-explorer/trace-utils.ts
@@ -4,6 +4,7 @@ import { Trace as TspTrace } from 'tsp-typescript-client/lib/models/trace';
 import { TraceViewerPanel } from '../trace-viewer-panel/trace-viewer-webview-panel';
 import { getExperimentManager, getTraceManager } from '../utils/backend-tsp-client-provider';
 import { traceLogger } from '../extension';
+import { updateNoExperimentsContext } from '../utils/backend-tsp-client-provider';
 import { KeyboardShortcutsPanel } from '../trace-viewer-panel/keyboard-shortcuts-panel';
 
 // eslint-disable-next-line no-shadow
@@ -62,93 +63,101 @@ export const fileHandler =
                 cancellable: true
             },
             async (progress, token) => {
-                if (token.isCancellationRequested) {
-                    progress.report({ message: ProgressMessages.COMPLETE, increment: 100 });
-                    return;
-                }
-
-                const filePath: string = resolvedTraceURI.fsPath;
-                if (!filePath) {
-                    traceLogger.showError(
-                        'Cannot open trace: could not retrieve path from URI for trace ' + resolvedTraceURI
-                    );
-                    return;
-                }
-
-                const name = path.basename(filePath);
-                progress.report({ message: ProgressMessages.FINDING_TRACES, increment: 10 });
-                /*
-                 * TODO: use backend service to find traces
-                 */
-                const tracesArray: string[] = [];
-                const fileStat = await vscode.workspace.fs.stat(resolvedTraceURI);
-                if (fileStat) {
-                    if (fileStat.type === vscode.FileType.Directory) {
-                        // Find recursively CTF traces
-                        const foundTraces = await findTraces(filePath);
-
-                        // No CTF traces found. Add root directory as trace directory.
-                        // Back-end will reject if it is not a trace
-                        if (foundTraces.length === 0) {
-                            foundTraces.push(filePath);
-                        }
-                        foundTraces.forEach(trace => tracesArray.push(trace));
-                    } else {
-                        // Open single trace file
-                        tracesArray.push(filePath);
+                try {
+                    if (token.isCancellationRequested) {
+                        progress.report({ message: ProgressMessages.COMPLETE, increment: 100 });
+                        return;
                     }
-                }
 
-                if (tracesArray.length === 0) {
-                    progress.report({ message: ProgressMessages.COMPLETE, increment: 100 });
-                    traceLogger.showError('No valid traces found in the selected directory: ' + resolvedTraceURI);
-                    return;
-                }
-
-                progress.report({ message: ProgressMessages.OPENING_TRACES, increment: 20 });
-                const traces = new Array<TspTrace>();
-                for (let i = 0; i < tracesArray.length; i++) {
-                    const traceName = path.basename(tracesArray[i]);
-                    const trace = await traceManager.openTrace(tracesArray[i], traceName);
-                    if (trace) {
-                        traces.push(trace);
-                    } else {
+                    const filePath: string = resolvedTraceURI.fsPath;
+                    if (!filePath) {
                         traceLogger.showError(
-                            'Failed to open trace: ' +
-                                traceName +
-                                '. There may be an issue with the server or the trace is invalid.'
+                            'Cannot open trace: could not retrieve path from URI for trace ' + resolvedTraceURI
                         );
+                        return;
                     }
-                }
 
-                if (token.isCancellationRequested) {
-                    rollbackTraces(traces, 20, progress);
-                    progress.report({ message: ProgressMessages.COMPLETE, increment: 50 });
-                    return;
-                }
+                    const name = path.basename(filePath);
+                    progress.report({ message: ProgressMessages.FINDING_TRACES, increment: 10 });
+                    /*
+                     * TODO: use backend service to find traces
+                     */
+                    const tracesArray: string[] = [];
+                    const fileStat = await vscode.workspace.fs.stat(resolvedTraceURI);
+                    if (fileStat) {
+                        if (fileStat.type === vscode.FileType.Directory) {
+                            // Find recursively CTF traces
+                            const foundTraces = await findTraces(filePath);
 
-                progress.report({ message: ProgressMessages.MERGING_TRACES, increment: 40 });
-                if (traces === undefined || traces.length === 0) {
-                    progress.report({ message: ProgressMessages.COMPLETE, increment: 30 });
-                    return;
-                }
+                            // No CTF traces found. Add root directory as trace directory.
+                            // Back-end will reject if it is not a trace
+                            if (foundTraces.length === 0) {
+                                foundTraces.push(filePath);
+                            }
+                            foundTraces.forEach(trace => tracesArray.push(trace));
+                        } else {
+                            // Open single trace file
+                            tracesArray.push(filePath);
+                        }
+                    }
 
-                const experiment = await experimentManager.openExperiment(name, traces);
-                const panel = TraceViewerPanel.createOrShow(context.extensionUri, experiment?.name ?? name, undefined);
-                if (experiment) {
-                    panel.setExperiment(experiment);
-                }
+                    if (tracesArray.length === 0) {
+                        progress.report({ message: ProgressMessages.COMPLETE, increment: 100 });
+                        traceLogger.showError('No valid traces found in the selected directory: ' + resolvedTraceURI);
+                        return;
+                    }
 
-                if (token.isCancellationRequested) {
+                    progress.report({ message: ProgressMessages.OPENING_TRACES, increment: 20 });
+                    const traces = new Array<TspTrace>();
+                    for (let i = 0; i < tracesArray.length; i++) {
+                        const traceName = path.basename(tracesArray[i]);
+                        const trace = await traceManager.openTrace(tracesArray[i], traceName);
+                        if (trace) {
+                            traces.push(trace);
+                        } else {
+                            traceLogger.showError(
+                                'Failed to open trace: ' +
+                                    traceName +
+                                    '. There may be an issue with the server or the trace is invalid.'
+                            );
+                        }
+                    }
+
+                    if (token.isCancellationRequested) {
+                        rollbackTraces(traces, 20, progress);
+                        progress.report({ message: ProgressMessages.COMPLETE, increment: 50 });
+                        return;
+                    }
+
+                    progress.report({ message: ProgressMessages.MERGING_TRACES, increment: 40 });
+                    if (traces === undefined || traces.length === 0) {
+                        progress.report({ message: ProgressMessages.COMPLETE, increment: 30 });
+                        return;
+                    }
+
+                    const experiment = await experimentManager.openExperiment(name, traces);
+                    const panel = TraceViewerPanel.createOrShow(
+                        context.extensionUri,
+                        experiment?.name ?? name,
+                        undefined
+                    );
                     if (experiment) {
-                        experimentManager.deleteExperiment(experiment.UUID);
+                        panel.setExperiment(experiment);
                     }
-                    rollbackTraces(traces, 20, progress);
-                    progress.report({ message: ProgressMessages.COMPLETE, increment: 10 });
-                    panel.dispose();
-                    return;
+
+                    if (token.isCancellationRequested) {
+                        if (experiment) {
+                            experimentManager.deleteExperiment(experiment.UUID);
+                        }
+                        rollbackTraces(traces, 20, progress);
+                        progress.report({ message: ProgressMessages.COMPLETE, increment: 10 });
+                        panel.dispose();
+                        return;
+                    }
+                    progress.report({ message: ProgressMessages.COMPLETE, increment: 30 });
+                } finally {
+                    updateNoExperimentsContext();
                 }
-                progress.report({ message: ProgressMessages.COMPLETE, increment: 30 });
             }
         );
     };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does
Fixes #296.
Triggers an update to the 'trace-explorer.noExperiments' context after a trace or experiment is opened.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test
The steps to reproduce the bug can be found in #296.
The bug can be reproduced on `master`
The bug should be fixed on this branch.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

When the server is online, the context is properly updated by a vscode-message sent from the frontend recieved by the backend.

#### Frontend:
```typescript
// 105-112 vscode-trace-explorer-opened-traces-widget.tsx
private initialized = false;
protected doHandleOpenedTracesChanged(payload: OpenedTracesUpdatedSignalPayload): void {
    if (!this.initialized) {
        this.initialized = true;
        return;
    }
    this._signalHandler.updateOpenedTraces(payload.getNumberOfOpenedTraces());
}
```
#### Backend:
```typescript
// 116-118 trace-explorer-opened-traces-webview-provider.ts
case VSCODE_MESSAGES.OPENED_TRACES_UPDATED:
    updateNoExperimentsContext();
    return;
```

I'm not sure why this code is triggered when the server is online and not when the server is offline.  I didn't dig too deep into investigating that because I'm not sure the relevancy, and I know that the events getting bounced around on the FE / BE can get really messy and hard to trace.  

There is also the tracking of `initialized` and we may simply not be sending the first signal intentionally.  This can be investigated because it may not be necessary to track anymore and could lead a cleaner solution.

I didn't deep dive into this.  I think updating the context on the backend after a trace is opened is a reasonable approach. WDYT?

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
