### PR TITLE
Add extra configuration parameter for vscode backend URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,9 @@ Forwarded ports can be seen in the 'Ports' view of the remote VsCode.  To open t
 
 Make sure that there is no Trace Server running on your local host. If the `Trace Viewer for VSCode` is unresponsive, stop the port forwarding by pressing the 'Stop Port Fowarding (Delete)' of the trace server port and restart remote VSCode.
 
-If you are a developers of the `Trace Viewer for VsCode` and want to modify and test the extension, you can [package it as a VSCode extension (.vsix)](#package-as-a-vscode-extension-vsix), upload the `VSIX` to the remote host and install the extension using the `Install from VSIX...` view menu of the `Extensions` view.
+Make sure that the `Enable separate backend URL` setting of the `Trace Viewer for VSCode` extension is deselected (because the port can only be forwarded once).
+
+If you are a developer of the `Trace Viewer for VsCode` and want to modify and test the extension, you can [package it as a VSCode extension (.vsix)](#package-as-a-vscode-extension-vsix), upload the `VSIX` to the remote host and install the extension using the `Install from VSIX...` view menu of the `Extensions` view.
 
 ## Release/publish
 

--- a/configs/errors.eslintrc.json
+++ b/configs/errors.eslintrc.json
@@ -51,12 +51,8 @@
     ],
     "no-new-wrappers": "error",
     "no-null/no-null": "error",
-    "no-shadow": [
-      "error",
-      {
-        "hoist": "all"
-      }
-    ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "error",
     "no-throw-literal": "error",
     "no-trailing-spaces": "error",
     "no-underscore-dangle": "off",

--- a/vscode-trace-extension/package.json
+++ b/vscode-trace-extension/package.json
@@ -258,12 +258,26 @@
                 "trace-compass.traceserver.url": {
                     "type": "string",
                     "default": "http://localhost:8080",
-                    "description": "Enter the trace server's URL, including port. Eg: http://localhost:8080."
+                    "description": "Enter the trace server's URL, including port. Eg: http://localhost:8080.",
+                    "order": 0
                 },
                 "trace-compass.traceserver.apiPath": {
                     "type": "string",
                     "default": "tsp/api",
-                    "description": "Enter the trace server's API path, to be appended to the server URL. Eg: 'tsp/api'."
+                    "description": "Enter the trace server's API path, to be appended to the server URL. Eg: 'tsp/api'.",
+                    "order": 1
+                },
+                "trace-compass.traceserver.enableSeparateBackendUrl": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable separate backend URL - Allows the vscode-backend to use a different URL. This is useful for a remote-deployment with K8s where the frontend needs to access an ingress, while backend needs to access the same trace-server using an internal URL.",
+                    "order": 2
+                },
+                "trace-compass.traceserver.backendUrl": {
+                    "type": "string",
+                    "default": "http://localhost:8080",
+                    "description": "Backend trace-server URL - Only used when separate backend URL is enabled.",
+                    "order": 4
                 }
             }
         },

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -14,7 +14,13 @@ import {
     keyboardShortcutsHandler
 } from './trace-explorer/trace-utils';
 import { TraceServerConnectionStatusService } from './utils/trace-server-status';
-import { updateTspClientUrl, isTraceServerUp, updateNoExperimentsContext } from './utils/backend-tsp-client-provider';
+import {
+    updateTspClientUrl,
+    isTraceServerUp,
+    updateNoExperimentsContext,
+    getTspClientUrl,
+    ClientType
+} from './utils/backend-tsp-client-provider';
 import { TraceExtensionLogger } from './utils/trace-extension-logger';
 import { ExternalAPI, traceExtensionAPI } from './external-api/external-api';
 import { TraceExtensionWebviewManager } from './utils/trace-extension-webview-manager';
@@ -78,9 +84,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extern
         vscode.workspace.onDidChangeConfiguration(async e => {
             if (
                 e.affectsConfiguration('trace-compass.traceserver.url') ||
-                e.affectsConfiguration('trace-compass.traceserver.apiPath')
+                e.affectsConfiguration('trace-compass.traceserver.apiPath') ||
+                e.affectsConfiguration('trace-compass.traceserver.backendUrl') ||
+                e.affectsConfiguration('trace-compass.traceserver.enableSeparateBackendUrl')
             ) {
-                const newTspClientURL = await updateTspClientUrl();
+                await updateTspClientUrl();
+                const newTspClientURL = getTspClientUrl(ClientType.FRONTEND);
 
                 // Signal the change to the `Opened traces` and `Available views` webview
                 tracesProvider.updateTraceServerUrl(newTspClientURL);

--- a/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as vscode from 'vscode';
 import { TraceServerConnectionStatusService } from '../utils/trace-server-status';
-import { getTraceServerUrl } from '../utils/backend-tsp-client-provider';
+import { ClientType, getTraceServerUrl } from '../utils/backend-tsp-client-provider';
 import { traceExtensionWebviewManager } from 'vscode-trace-extension/src/extension';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 
@@ -93,7 +93,7 @@ export abstract class AbstractTraceExplorerProvider implements vscode.WebviewVie
 					img-src ${webview.cspSource};
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} 'unsafe-inline';
-					connect-src ${getTraceServerUrl()};
+					connect-src ${getTraceServerUrl(ClientType.BACKEND)} ${getTraceServerUrl(ClientType.FRONTEND)};
 					font-src ${webview.cspSource}">
 				<link href="${codiconsUri}" rel="stylesheet" />
 				<base href="${packUri}/">

--- a/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/available-views/trace-explorer-available-views-webview-provider.ts
@@ -7,8 +7,8 @@ import * as vscode from 'vscode';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import { TraceViewerPanel } from '../../trace-viewer-panel/trace-viewer-webview-panel';
-import { getTspClientUrl } from '../../utils/backend-tsp-client-provider';
 import { AbstractTraceExplorerProvider } from '../abstract-trace-explorer-provider';
+import { ClientType, getTspClientUrl } from 'vscode-trace-extension/src/utils/backend-tsp-client-provider';
 
 const JSONBig = JSONBigConfig({
     useNativeBigInt: true
@@ -48,7 +48,7 @@ export class TraceExplorerAvailableViewsProvider extends AbstractTraceExplorerPr
                         // Post the tspTypescriptClient
                         this._view?.webview.postMessage({
                             command: VSCODE_MESSAGES.SET_TSP_CLIENT,
-                            data: getTspClientUrl()
+                            data: getTspClientUrl(ClientType.FRONTEND)
                         });
                         if (this._selectedExperiment !== undefined) {
                             signalManager().emit('EXPERIMENT_SELECTED', this._selectedExperiment);

--- a/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/opened-traces/trace-explorer-opened-traces-webview-provider.ts
@@ -5,7 +5,7 @@ import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
 import * as vscode from 'vscode';
 import { convertSignalExperiment } from 'vscode-trace-common/lib/signals/vscode-signal-converter';
 import { TraceViewerPanel } from '../../trace-viewer-panel/trace-viewer-webview-panel';
-import { getTspClientUrl, updateNoExperimentsContext } from '../../utils/backend-tsp-client-provider';
+import { ClientType, getTspClientUrl, updateNoExperimentsContext } from '../../utils/backend-tsp-client-provider';
 import { VSCODE_MESSAGES } from 'vscode-trace-common/lib/messages/vscode-message-manager';
 import { AbstractTraceExplorerProvider } from '../abstract-trace-explorer-provider';
 
@@ -82,7 +82,7 @@ export class TraceExplorerOpenedTracesViewProvider extends AbstractTraceExplorer
                         // Post the tspTypescriptClient
                         this._view?.webview.postMessage({
                             command: VSCODE_MESSAGES.SET_TSP_CLIENT,
-                            data: getTspClientUrl()
+                            data: getTspClientUrl(ClientType.FRONTEND)
                         });
                         if (this._selectedExperiment !== undefined) {
                             // tabActivatedSignal will select the experiment in the opened-traces view

--- a/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/keyboard-shortcuts-panel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getTraceServerUrl } from '../utils/backend-tsp-client-provider';
+import { ClientType, getTraceServerUrl } from '../utils/backend-tsp-client-provider';
 
 /**
  * Manages the keyboard and mouse shortcuts panel
@@ -56,7 +56,7 @@ export class KeyboardShortcutsPanel {
 					img-src ${webview.cspSource};
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} 'unsafe-inline';
-					connect-src ${getTraceServerUrl()};
+					connect-src ${getTraceServerUrl(ClientType.BACKEND)} ${getTraceServerUrl(ClientType.FRONTEND)};
                     font-src ${webview.cspSource}">
                 <base href="${packUri}/">
 			</head>

--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { Experiment } from 'tsp-typescript-client/lib/models/experiment';
-import { getTspClientUrl, getTraceServerUrl } from '../utils/backend-tsp-client-provider';
+import { ClientType, getTraceServerUrl, getTspClientUrl } from '../utils/backend-tsp-client-provider';
 import { TraceServerConnectionStatusService } from '../utils/trace-server-status';
 import { OutputDescriptor } from 'tsp-typescript-client/lib/models/output-descriptor';
 import { handleStatusMessage, handleRemoveMessage, setStatusFromPanel } from '../common/trace-message';
@@ -263,13 +263,13 @@ export class TraceViewerPanel {
                             const wrapper: string = JSONBig.stringify(this._experiment);
                             this._panel.webview.postMessage({
                                 command: VSCODE_MESSAGES.SET_TSP_CLIENT,
-                                data: getTspClientUrl(),
+                                data: getTspClientUrl(ClientType.FRONTEND),
                                 experiment: wrapper
                             });
                         } else {
                             this._panel.webview.postMessage({
                                 command: VSCODE_MESSAGES.SET_TSP_CLIENT,
-                                data: getTspClientUrl()
+                                data: getTspClientUrl(ClientType.FRONTEND)
                             });
                         }
                         this.loadTheme();
@@ -531,7 +531,7 @@ export class TraceViewerPanel {
 					img-src ${webview.cspSource} data:;
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} 'unsafe-inline';
-					connect-src ${getTraceServerUrl()};
+					connect-src ${getTraceServerUrl(ClientType.BACKEND)} ${getTraceServerUrl(ClientType.FRONTEND)};
 					font-src ${webview.cspSource} data:">
 				<link href="${codiconsUri}" rel="stylesheet" />
 				<base href="${packUri}/">
@@ -569,7 +569,7 @@ export class TraceViewerPanel {
 					img-src ${webview.cspSource} data:;
 					script-src 'nonce-${nonce}' 'unsafe-eval';
 					style-src ${webview.cspSource} 'unsafe-inline';
-					connect-src ${getTraceServerUrl()};
+					connect-src ${getTraceServerUrl(ClientType.BACKEND)} ${getTraceServerUrl(ClientType.FRONTEND)};
 					font-src ${webview.cspSource} data:">
 				<link href="${codiconsUri}" rel="stylesheet" />
 				<base href="${packUri}/">


### PR DESCRIPTION
### What it does

The vscode-trace-extension code is written so that some REST calls towards the server are done by the vscode backend, and some from the vscode frontend (webviews). In some situations can be useful to be able to specify different URLs for the REST calls, depending on where the REST call is done (vscode frontend or backend). For example when deploying on a k8s cluster, where the vscode backend can communicate to the trace server without going through an ingress.

This PR add the setting to be able to select the URL used from the vscode backend. 

### How to test

To make sure that the added feature works as expected (i.e. the REST calls are done to different URLs and/or ports), a simple test setup can be configured locally by:

- starting 2 trace-servers on 2 different ports
  - ```trace-server -data ~/.trace-server-webapp8080 -vmargs -Dtraceserver.port=8080 -Dtraceserver.host=127.0.0.1```
  - ```trace-server -data ~/.trace-server-webapp8081 -vmargs -Dtraceserver.port=8081 -Dtraceserver.host=127.0.0.1```

- apply the following patch to the tsp-typescript-client project (dependency of vscode-trace-ext) and use it to build the vscode-trace-ext from this branch (see yarn link instructions on the project main readme)

```
-- a/tsp-typescript-client/src/protocol/rest-client.ts
+++ b/tsp-typescript-client/src/protocol/rest-client.ts
@@ -104,6 +104,7 @@ export class RestClient {
         body?: any,
         normalizer?: Normalizer<T>,
     ): Promise<TspClientResponse<Deserialized<T>>> {
+        console.log(`[${this.feOrBe()}] TSP_client#performRequest() - method: ${method}, url: ${url}, body: ${this.jsonStringify(body)} `);
         let response: HttpResponse;
         try {
             response = await this.httpRequest({
@@ -167,6 +168,16 @@ export class RestClient {
         return JSONBig.stringify(data);
     }
 
+    protected static feOrBe(): string {
+        const isBrowser = typeof window !== "undefined" && window instanceof Window;
+
+        if (isBrowser) {
+            return "FRONTEND"
+        }
+        
+        return "BACKEND"
+    }
+
     /**
      * Parse JSON-encoded data. If a number is too large to fit into a regular
      * `number` then it will be deserialized as `BigInt`.
diff --git a/tsp-typescript-client/tsconfig.json b/tsp-typescript-client/tsconfig.json
index 5f39976..4509bc5 100644
--- a/tsp-typescript-client/tsconfig.json
+++ b/tsp-typescript-client/tsconfig.json
@@ -7,7 +7,7 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "lib": [
-            "es6"
+            "es6","DOM", "ES2020"
         ],
         "alwaysStrict": true,
         "strictNullChecks": true,
 ```

- Run the vscode-trace-extension in development mode, access the settings and enable the backend URL setting it to localhost:8081

- Try to open a trace and look into the console (browser devtools). It will show which calls are done from the frontend/backend and where are they going. Of course should be going to the URLs specified in the settings :)

### Follow-ups

No follow ups planned as of now

### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
