### PR TITLE
Minimize jitter related to creation of trace explorer webview views

### DIFF
--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -39,6 +39,10 @@ export const messenger = new Messenger({ ignoreHiddenViews: false });
 export async function activate(context: vscode.ExtensionContext): Promise<ExternalAPI> {
     traceLogger = new TraceExtensionLogger('Trace Extension');
 
+    // Initialize noExperiments/serverUp in a way to avoid WebviewViews creation jitter
+    vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', true);
+    vscode.commands.executeCommand('setContext', 'traceViewer.serverUp', false);
+
     const resourceTypeHandler: TraceExplorerResourceTypeHandler = TraceExplorerResourceTypeHandler.getInstance();
 
     await updateTspClientUrl();
@@ -239,10 +243,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extern
 
     vscode.commands.executeCommand('setContext', 'traceViewer.markerSetsPresent', false);
     vscode.commands.executeCommand('setContext', 'traceViewer.markerCategoriesPresent', false);
-
-    // Initialize noExperiments/serverUp in a way so that trace explorer webviews are initialized
-    vscode.commands.executeCommand('setContext', 'trace-explorer.noExperiments', false);
-    vscode.commands.executeCommand('setContext', 'traceViewer.serverUp', true);
 
     // Refresh to trigger rendering trace explorer or welcome page
     vscode.commands.executeCommand('trace-explorer.refreshContext');

--- a/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/abstract-trace-explorer-provider.ts
@@ -60,6 +60,20 @@ export abstract class AbstractTraceExplorerProvider implements vscode.WebviewVie
         _context: vscode.WebviewViewResolveContext,
         _token: vscode.CancellationToken
     ): void {
+        if (this._view) {
+            // The initialization of webview views can be tricky. There are the 4 trace
+            // explorer views and also welcome view, one set of which should be displayed
+            // at any given moment, depending on context variables. However it can be
+            // possible to have jitter initally if the context variables change value
+            // quickly, which can result in webview views being resolved again without
+            // the "onDispose" event being sent. We can detect and correct for this
+            // condition, in case a change in the code brings it back again
+            console.warn(
+                'AbstractTraceExplorerProvider#resolveWebviewView(): unexpectedly called again without first disposing of old webview view: ' +
+                    this.constructor.name
+            );
+            this.dispose();
+        }
         this._view = webviewView;
         webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
 

--- a/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
+++ b/vscode-trace-extension/src/trace-explorer/properties/trace-explorer-properties-view-webview-provider.ts
@@ -80,6 +80,7 @@ export class TraceExplorerItemPropertiesProvider extends AbstractTraceExplorerPr
         signalManager().off('EXPERIMENT_SELECTED', this.handleExperimentChanged);
         signalManager().off('CLOSE_TRACEVIEWERTAB', this.handleTabClosed);
         this._disposables.forEach(disposable => disposable.dispose());
+        super.dispose();
     }
 
     handleTabClosed = (expUUID: string) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The initialization of webview views can be tricky. There are the 4 trace explorer views and also welcome view, one set of which should be displayed at any given moment, depending on context variables. However it can be possible to have jitter initially if the context variables change value quickly, which can result in webview views being resolved again without the "onDispose" event being sent. When this happens, the webview views have no opportunity to unregister their event listeners, causing leaks.

To address the jitter, context variables `trace-explorer.noExperiments` and `traceViewer.serverUp` are initialized at activation with values that will prevent the trace explorer webview views being "resolved", causing an unambiguous situation where the welcome view will be displayed instead, until a trace server is started or detected to be running, and through communication with it, it's established that one or more experiment exists on it.
                               
In case there might still be jitter in cases that were missed, or in case some in re-introduced in later changes, we catch the situation where a trace explorer webview view is re-resolved without having been disposed and in that case dispose of its listeners and print a warning message on the console.

Also, corrected that one of the trace explorer webview views, `TraceExplorerItemPropertiesProvider`, was not calling "super.dispose()" in its own dispose() method. Since this is where the "resolved" webview is set, this would trip the warning added in this commit, even if the old view had been disposed correctly.


### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Scenarios: 

Try all possible combinations of starting the trace viewer extension with and without a trace server and an experiment already present or not, and confirm that no webview view leaks event listeners (i.e. that they are all correctly disposed). Also confirm that all scenarios involving further starting/stopping the trace server and creating/deleting an experiment, still works as before. 

Fresh start with and without a trace server already started, with and without an experiment already present. 

There is a temporary commit present, that adds some debug traces to help test, that will be removed before merging. Using that commit, it's possible to confirm whether the trace explorer's webview views are disposed and as well follow important changes in value for the context variables. 

For example, if the trace server is already started and has an experiment, the following debug traces will be printed at startup:

_isTraceServerUp() - set traceviewer.serverUp: true
extensionHostProcess.js:178
updateServerStatus() - set traceviewer.serverUp: true
extensionHostProcess.js:178
isTraceServerUp() - set traceviewer.serverUp: true
extensionHostProcess.js:178
updateNoExperimentsContext - set trace-explorer.noExperiments: false
extensionHostProcess.js:178_
__vscode calling resolveWebviewView() to initialize webview: TraceExplorerOpenedTracesViewProvider
extensionHostProcess.js:178
vscode calling resolveWebviewView() to initialize webview: TraceExplorerAvailableViewsProvider
extensionHostProcess.js:178
vscode calling resolveWebviewView() to initialize webview: TraceExplorerTimeRangeDataProvider
extensionHostProcess.js:178
vscode calling resolveWebviewView() to initialize webview: TraceExplorerItemPropertiesProvider
extensionHostProcess.js:178__

Then, closing the experiment, we can see the 4 webview views being disposed:

_updateNoExperimentsContext - set trace-explorer.noExperiments: true
extensionHostProcess.js:178_
__Cleaning-up after vscode disposed webview: TraceExplorerItemPropertiesProvider
extensionHostProcess.js:178
Cleaning-up after vscode disposed webview: TraceExplorerTimeRangeDataProvider
extensionHostProcess.js:178
Cleaning-up after vscode disposed webview: TraceExplorerAvailableViewsProvider
extensionHostProcess.js:178
Cleaning-up after vscode disposed webview: TraceExplorerOpenedTracesViewProvider__


It's also possible to use the debugger to confirm whether there are still event listener leaks - see #307 for the details how to set that up.

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

N/A
### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
