### PR TITLE
Programmatic experiment deletion

### DIFF
--- a/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
+++ b/vscode-trace-extension/src/trace-viewer-panel/trace-viewer-webview-panel.ts
@@ -431,6 +431,9 @@ export class TraceViewerPanel {
         signalManager().emit('EXPERIMENT_OPENED', experiment);
         signalManager().emit('TRACEVIEWERTAB_ACTIVATED', experiment);
     }
+    getExperiment(): Experiment | undefined {
+        return this._experiment;
+    }
 
     addOutput(descriptor: OutputDescriptor): void {
         const wrapper = JSONBigUtils.stringify(descriptor);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Enhances "traces.openTraceFile" command to return the UUID of the opened experiment (rather than returning a void value in all cases).  Provides a new command "traces.removeTrace" that accepts a UUID referring to an experiment (obtained by an earlier call to traces.openTraceFile), and removes any open trace viewer panels associated with that experiment, as well as removing it from the experiment manager.

These changes allow trace opening and closing to be accomplished programmatically from other vscode extensions.  Without these changes, an experiment must be closed from within the trace viewer UI, even if another vscode extension was used to delete an underlying trace file.

### How to test

From a vscode extension other than vscode-trace-extension, invoke the traces.openTraceFile command with valid argument to obtain a UUID for the opened trace.  Verify that the opened trace is visible within a trace viewer UI panel, and also listed in the Opened Traces list.  Again, from a vscode extension other than vscode-trace-extension, arrange for the traces.removeTrace to be called, using the previously-obtained UUID as an argument.  Verify that no trace viewer UI panel is still open on the previously-opened trace, and that the previously-opened trace is no longer represented in the "Opened Traces" list.

### Follow-ups

None identified.

### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
