### PR TITLE
Propagate trace server started signal to webview and use it in refresh trace explorer

### DIFF
--- a/vscode-trace-common/src/messages/vscode-messages.ts
+++ b/vscode-trace-common/src/messages/vscode-messages.ts
@@ -75,6 +75,7 @@ export const viewRangeUpdated: NotificationType<any> = { method: VSCODE_MESSAGES
 export const selectionRangeUpdated: NotificationType<any> = { method: VSCODE_MESSAGES.SELECTION_RANGE_UPDATED };
 export const experimentUpdated: NotificationType<any> = { method: VSCODE_MESSAGES.EXPERIMENT_UPDATED };
 export const setTheme: NotificationType<any> = { method: VSCODE_MESSAGES.SET_THEME };
+export const traceServerStarted: NotificationType<void> = { method: VSCODE_MESSAGES.TRACE_SERVER_STARTED };
 export const traceServerUrlChanged: NotificationType<string> = { method: VSCODE_MESSAGES.TRACE_SERVER_URL_CHANGED };
 export const experimentSelected: NotificationType<any> = { method: VSCODE_MESSAGES.EXPERIMENT_SELECTED };
 export const requestSelectionChange: NotificationType<any> = { method: VSCODE_MESSAGES.REQUEST_SELECTION_RANGE_CHANGE };

--- a/vscode-trace-extension/src/extension.ts
+++ b/vscode-trace-extension/src/extension.ts
@@ -257,6 +257,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extern
             await serverStatusService.updateServerStatus(isUp);
             if (isUp) {
                 await updateNoExperimentsContext();
+                if (tracesProvider) {
+                    // Trigger webview refresh
+                    tracesProvider.postMessagetoWebview(VSCODE_MESSAGES.TRACE_SERVER_STARTED, undefined);
+                }
             }
         })
     );

--- a/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
+++ b/vscode-trace-webviews/src/trace-explorer/opened-traces/vscode-trace-explorer-opened-traces-widget.tsx
@@ -11,6 +11,7 @@ import { TspClientProvider } from 'vscode-trace-common/lib/client/tsp-client-pro
 import {
     experimentOpened,
     setTspClient,
+    traceServerStarted,
     traceServerUrlChanged,
     traceViewerTabActivated
 } from 'vscode-trace-common/lib/messages/vscode-messages';
@@ -65,6 +66,10 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
         }
     };
 
+    private _onVscodeServerStarted = (): void => {
+        signalManager().emit('TRACE_SERVER_STARTED');
+    };
+
     private _onVscodeExperimentOpened = (data: any): void => {
         if (data) {
             signalManager().emit('EXPERIMENT_OPENED', JSONBigUtils.parse(data, Experiment));
@@ -86,6 +91,7 @@ class TraceExplorerOpenedTraces extends React.Component<{}, OpenedTracesAppState
         this._signalHandler = new VsCodeMessageManager(messenger);
 
         messenger.onNotification(setTspClient, this._onVscodeSetTspClient);
+        messenger.onNotification(traceServerStarted, this._onVscodeServerStarted);
         messenger.onNotification(traceServerUrlChanged, this._onVscodeUrlChanged);
         messenger.onNotification(experimentOpened, this._onVscodeExperimentOpened);
         messenger.onNotification(traceViewerTabActivated, this._onVscodeUrlTraceViewerTabActivated);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

- Propagate traceServerStarted signal to opened traces webview. This was missed in commit 177c6e8.
- Refresh also "Opened Traces" view when executing refreshContext. This will also refresh the "Opened Traces" view when refreshing the context, e.g. when user presses the "Refresh Trace Explorer" button.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

- Open Network tab of Web developer tools
- Start trace server
- Press "Refresh Trace Server" button
- Observe the Network tab. The fetchExperiments method should be called

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

Will help with PR #332. It will refresh "Opened Traces" view.

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
