### PR TITLE
Remove on-close events from json-config-editor

### DIFF
--- a/vscode-trace-extension/src/json-editor/file-service.ts
+++ b/vscode-trace-extension/src/json-editor/file-service.ts
@@ -30,8 +30,6 @@ export class FileService {
             '* • Submit the current config',
             '* • Save this config for future use',
             '* • Load an existing config file',
-            '*',
-            '* You can also submit by simply closing the file',
             '*/',
             JSON.stringify(json, undefined, 2)
         ].join('\n');

--- a/vscode-trace-extension/src/json-editor/json-editor.ts
+++ b/vscode-trace-extension/src/json-editor/json-editor.ts
@@ -20,7 +20,6 @@ import { FileService } from './file-service';
 export class JsonConfigEditor {
     private _tempFilePath: string = '';
     private isEditing: boolean = false;
-    private isAwaitingUserSubmit: boolean = false;
     private availableConfigurations: CustomizationConfigObject[] = [];
     private userClickedSubmit: boolean = false;
     private trackedEditor?: vscode.TextEditor;
@@ -51,8 +50,6 @@ export class JsonConfigEditor {
                     throw Error(
                         'a config editing session is already active - Please close the active editor and try again.'
                     );
-                if (this.isAwaitingUserSubmit)
-                    throw Error('awaiting prompt response - Please chose to if you want to submit then try again.');
 
                 this.availableConfigurations = configs;
                 const selectedConfig = await this.promptUserSchemaSelection(configs);
@@ -276,7 +273,6 @@ export class JsonConfigEditor {
 
         try {
             this.isEditing = false;
-            this.isAwaitingUserSubmit = true;
             // Write content to temp file for validation
             if (fs.existsSync(this.tempFilePath)) {
                 fs.writeFileSync(this.tempFilePath, document.getText(), 'utf8');
@@ -284,23 +280,15 @@ export class JsonConfigEditor {
                 throw new Error('Temporary file not found');
             }
 
+            if (!this.userClickedSubmit) {
+                return;
+            }
+
             const validation = await this.schemaService.validateJsonFile(this.tempFileUri, schema);
 
             if (validation.isValid && validation.content) {
-                const submit = this.userClickedSubmit
-                    ? 'Yes'
-                    : await vscode.window.showInformationMessage(
-                          'Do you want to submit this configuration?',
-                          'Yes',
-                          'No'
-                      );
-
-                if (submit === 'Yes') {
-                    vscode.window.showInformationMessage('Configuration submitted successfully');
-                    return validation.content;
-                }
-
-                return undefined; // User chose not to submit
+                vscode.window.showInformationMessage('Configuration submitted successfully');
+                return validation.content;
             } else if (validation.errors) {
                 this.displayValidationErrorDialogue(
                     `Your configuration was not submitted because it had errors`,
@@ -321,7 +309,6 @@ export class JsonConfigEditor {
     private resetState = () => {
         this.fileService.cleanupTempFile(this.tempFilePath);
         this.userClickedSubmit = false;
-        this.isAwaitingUserSubmit = false;
         this.isEditing = false;
         this.trackedEditor = undefined;
         this.tempFilePath = '';


### PR DESCRIPTION
### What it does

Removes the prompt for config submission if the user closes the file.  We found it was counter-intuitive UI.  This will force the user to use the button commands in the nav bar.

### How to test

Close the custom analysis json config file.  No prompts should show up!

### Follow-ups

Really just continued UI/UX improvements for custom analysis. 

### Review checklist

- [x ] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
