### PR TITLE
[traceviewer-base] explicitly request recent prettier dependency

### DIFF
--- a/local-libs/traceviewer-libs/base/package.json
+++ b/local-libs/traceviewer-libs/base/package.json
@@ -25,6 +25,7 @@
         "eslint-plugin-import": "^2.21.2",
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-react": "^7.20.0",
+        "prettier": "^3.6.2",
         "rimraf": "^5.0.0",
         "typescript": "4.9.5"
     },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
When the traceviewer-libs git subtree was initially added, running prettier (yarn format:check) would fail locally. This was since determine to be because this repo here was already pulling a more recent version of "prettier" than the theia extension repo: v3.x vs v2.x.

The local version of the subtree already has the libraries' code adapted to pass the check with prettier@3. That version was explicitly added as a devDependency to the traceviewer- react-components library, but for completeness, we now add it to traceviwewer-base as well, to be sure the format check will be identical in both repositories, no matter the version of prettier that may be pulled in the root package.json or other components, in either / both repositories.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Confirm that CI passes

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
