### PR TITLE
[traceviewer-libs] correct git subtree push commands

### DIFF
--- a/local-libs/traceviewer-libs/README.md
+++ b/local-libs/traceviewer-libs/README.md
@@ -84,9 +84,9 @@ git remote add traceviewer-libs git@github.com:eclipse-cdt-cloud/traceviewer-lib
 # assumption: remote for official repo is named "origin"
 git checkout master && git pull origin master
 # push the latest local library changes to the git subtree upstream:
-git subtree push -p <subtree folder> <subtree remote repo> <remote review branch>
+git subtree push --prefix <subtree folder> <subtree remote repo> <remote review branch>
 # more concrete example: 
-git subtree push -p local-libs/traceviewer-libs traceviewer-libs update-from-vscode-trace-extension
+git subtree push --prefix local-libs/traceviewer-libs traceviewer-libs update-from-vscode-trace-extension
 
 # Then create a PR from the freshly pushed branch "update-from-vscode-trace-extension".
 # If tweaks are necessary, e.g. to remove some changes that are only relevant to 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

<!-- Include relevant issues and describe how they are addressed. -->
In the subtree README, "git subtree push -p <subtree folder" was documented. Not sure where this came from, but my local git won't accept it, instead expecting:
"git subtree push --prefix <subtree folder"

Corrected in this commit.

### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
N/A - just a documentation update

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
N/A

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
