### PR TITLE
Change input parameters for vscode writeFile

### DIFF
--- a/vscode-trace-extension/src/json-editor/file-service.ts
+++ b/vscode-trace-extension/src/json-editor/file-service.ts
@@ -55,7 +55,9 @@ export class FileService {
             });
         } else {
             // If no editor is open for this file, just write to the file
-            await vscode.workspace.fs.writeFile(fileUri, Buffer.from(fileContent, 'utf-8'));
+            const buffer = Buffer.from(fileContent, 'utf-8');
+            const utf8Array = new Uint8Array(buffer);
+            await vscode.workspace.fs.writeFile(fileUri, utf8Array);
         }
 
         const document = await vscode.workspace.openTextDocument(fileUri);

--- a/vscode-trace-extension/src/json-editor/json-editor.ts
+++ b/vscode-trace-extension/src/json-editor/json-editor.ts
@@ -186,10 +186,10 @@ export class JsonConfigEditor {
         }
 
         try {
-            await vscode.workspace.fs.writeFile(
-                uri,
-                Buffer.from(JSON.stringify(validation.content, undefined, 2), 'utf8')
-            );
+            const jsonString = JSON.stringify(validation.content, undefined, 2);
+            const buffer = Buffer.from(jsonString);
+            const unit8Array = new Uint8Array(buffer);
+            await vscode.workspace.fs.writeFile(uri, unit8Array);
 
             vscode.window.showInformationMessage('Configuration file saved successfully');
             return true;


### PR DESCRIPTION

### What it does

The second input for vscode.workspace.fs.writeFile was a buffer but now it's thowing an error.

```error
Argument of type 'Buffer' is not assignable to parameter of type 'Uint8Array<ArrayBufferLike>'.
  The types of 'slice(...).buffer' are incompatible between these types.
    Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
      Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
        Types of property '[Symbol.toStringTag]' are incompatible.
          Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.ts(2345)
```

This converts the buffer to a Uint8Array to resolve the error.

### How to test

This touches the functionality to save and load configuration files for custom analysis.  Test both saving and loading local files works.

### Follow-ups

Nothing to follow up.   This is a follow up for the customization.

### Review checklist

- [ x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
