### PR TITLE
Update parsing of sampling to match tsp specification

### DIFF
--- a/local-libs/traceviewer-libs/react-components/src/components/generic-xy-output-component.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/generic-xy-output-component.tsx
@@ -388,7 +388,7 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
 
     private buildLabels(xValues: Sampling, unit: string): string[] {
         if (isRangeSampling(xValues)) {
-            return xValues.map(range => `[${range[0]} ${unit}, ${range[1]} ${unit}]`);
+            return xValues.map(range => `[${range.start} ${unit}, ${range.end} ${unit}]`);
         } else if (isCategorySampling(xValues)) {
             return xValues.map(val => `${val} ${unit}`);
         } else if (isTimestampSampling(xValues)) {


### PR DESCRIPTION
The tsp-typescript-client was modified to comply to tsp specification for sampling. This change synchronizes the implementation.
### What it does

Update to match the latest update in tsp-typescript-client: https://github.com/eclipse-cdt-cloud/tsp-typescript-client/pull/144

Related issue: https://github.com/eclipse-tracecompass-incubator/org.eclipse.tracecompass.incubator/issues/236

### How to test

Can be tested with a lttng-ust trace using function density view, everything should work the same as previously.

### Follow-ups

No follow-ups.

### Review checklist

- [Y] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
