### PR TITLE
Add progress wheel if analysis is running for density charts

### DIFF
--- a/local-libs/traceviewer-libs/react-components/src/components/generic-xy-output-component.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/generic-xy-output-component.tsx
@@ -33,6 +33,8 @@ import {
     computeYRange
 } from './utils/xy-shared';
 import { parse } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 interface XYDataset {
     id?: number | string;
@@ -1118,8 +1120,13 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
                 >
                     {this.chooseReactChart()}
                     {this.state.outputStatus === ResponseStatus.RUNNING && (
-                        <div className="analysis-running-overflow" style={{ width: this.getChartWidth() }}>
+                        <div
+                            id={this.props.traceId + this.props.outputDescriptor.id + 'focusContainer'}
+                            className="analysis-running-overflow"
+                            style={{ width: this.getChartWidth() }}
+                        >
                             <div>
+                                <FontAwesomeIcon icon={faSpinner} spin style={{ marginRight: '5px' }} />
                                 <span>Analysis running</span>
                             </div>
                         </div>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

Add progress wheel if analysis is running for density charts. This was missing and it will look like in the following screenshot.

<img width="1160" height="254" alt="image" src="https://github.com/user-attachments/assets/afa019cd-d7a4-4abd-a90c-ffe8b65bb0d1" />

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Open a density chart and observer the analysis running wheel. Use e.g. Function Duration Density with Trace Compass server and LTTng UST trace with call stack events.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

N/A

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
