### PR TITLE
Add legends column to XY trace viewer

### DIFF
--- a/local-libs/traceviewer-libs/react-components/src/components/abstract-xy-output-component.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/abstract-xy-output-component.tsx
@@ -23,10 +23,12 @@ import { isEqual } from 'lodash';
 import {
     applyYAxis,
     buildTreeStateFromModel,
+    buildLegendColors,
     ColorAllocator,
     computeYRange,
     getTimeForX as timeForX,
     getXForTime as xForTime,
+    registerSeriesNames,
     zoomRange,
     panRange,
     setSpinnerVisible
@@ -66,6 +68,7 @@ export type AbstractXYOutputState = AbstractTreeOutputState & {
     columns: ColumnHeader[];
     allMax: number;
     allMin: number;
+    legendColors: Record<number, string>;
     cursor?: string;
 };
 
@@ -156,6 +159,7 @@ export abstract class AbstractXYOutputComponent<
     private _debouncedUpdateXY = debounce(() => this.updateXY(), 500);
 
     private colors = new ColorAllocator();
+    private seriesNameById = new Map<number, string>();
 
     constructor(props: P) {
         super(props);
@@ -310,7 +314,8 @@ export abstract class AbstractXYOutputComponent<
                         defaultOrderedIds: built.defaultOrderedIds,
                         collapsedNodes: built.collapsedNodes,
                         checkedSeries: built.checkedSeries,
-                        columns: built.columns as any
+                        columns: built.columns as any,
+                        legendColors: {}
                     },
                     () => {
                         this.updateXY();
@@ -349,6 +354,7 @@ export abstract class AbstractXYOutputComponent<
                     onOrderChange={this.onOrderChange}
                     onOrderReset={this.onOrderReset}
                     headers={this.state.columns}
+                    legendColors={this.state.legendColors}
                 />
             </div>
         ) : undefined;
@@ -464,6 +470,7 @@ export abstract class AbstractXYOutputComponent<
     }
 
     private buildScatterData(seriesObj: XYSeries[]) {
+        registerSeriesNames(this.seriesNameById, seriesObj);
         const dataSetArray = new Array<any>();
         let xValues: bigint[] = [];
         const offset = this.props.viewRange.getOffset() ?? BigInt(0);
@@ -498,13 +505,17 @@ export abstract class AbstractXYOutputComponent<
 
         // flushSync: force immediate state update instead of waiting for React 18's automatic batching
         flushSync(() => {
-            this.setState({ xyData: scatterData });
+            this.setState({
+                xyData: scatterData,
+                legendColors: buildLegendColors(this.state.xyTree, this.colors, this.seriesNameById)
+            });
         });
 
         this.calculateYRange();
     }
 
     private buildXYData(seriesObj: XYSeries[]) {
+        registerSeriesNames(this.seriesNameById, seriesObj);
         const dataSetArray = new Array<any>();
         let xValues: bigint[] = [];
         seriesObj.forEach(series => {
@@ -526,7 +537,10 @@ export abstract class AbstractXYOutputComponent<
 
         // flushSync: force immediate state update instead of waiting for React 18's automatic batching
         flushSync(() => {
-            this.setState({ xyData: lineData });
+            this.setState({
+                xyData: lineData,
+                legendColors: buildLegendColors(this.state.xyTree, this.colors, this.seriesNameById)
+            });
         });
 
         this.calculateYRange();

--- a/local-libs/traceviewer-libs/react-components/src/components/generic-xy-output-component.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/generic-xy-output-component.tsx
@@ -24,13 +24,15 @@ import * as d3 from 'd3';
 import {
     applyYAxis,
     buildTreeStateFromModel,
+    buildLegendColors,
     ColorAllocator,
     getTimeForX as timeForX,
     zoomRange,
     panRange,
     setSpinnerVisible,
     rowsToCsv,
-    computeYRange
+    computeYRange,
+    registerSeriesNames
 } from './utils/xy-shared';
 import { parse } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -71,6 +73,7 @@ interface GenericXYState extends AbstractTreeOutputState {
     collapsedNodes: number[];
     allMax: number;
     allMin: number;
+    legendColors: Record<number, string>;
     cursor: string;
     timelineUnit: string;
     timelineUnitType: TimelineUnitType;
@@ -127,6 +130,7 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
     private clickedMouseButton = -1;
 
     private readonly colors = new ColorAllocator();
+    private readonly seriesNameById = new Map<number, string>();
 
     private readonly _debouncedUpdateXY = debounce(() => this.updateXY(), 500);
 
@@ -145,6 +149,7 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
                 : [],
             xyData: { labels: [], datasets: [], labelIndices: [] },
             columns: [{ title: 'Name', sortable: true }],
+            legendColors: {},
             allMax: 0,
             allMin: 0,
             cursor: 'default',
@@ -203,6 +208,7 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
                     onOrderChange={this.onOrderChange}
                     onOrderReset={this.onOrderReset}
                     headers={this.state.columns}
+                    legendColors={this.state.legendColors}
                 />
             </div>
         ) : undefined;
@@ -246,7 +252,8 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
                         defaultOrderedIds: built.defaultOrderedIds,
                         collapsedNodes: built.collapsedNodes,
                         checkedSeries: built.checkedSeries,
-                        columns: built.columns as any
+                        columns: built.columns as any,
+                        legendColors: {}
                     },
                     () => {
                         this._debouncedUpdateXY();
@@ -343,8 +350,15 @@ export class GenericXYOutputComponent extends AbstractTreeOutputComponent<Generi
         this.isTimeAxis = !!series[0].xValues;
         this.mode = st === 'scatter' ? ChartMode.SCATTER : st === 'line' ? ChartMode.LINE : ChartMode.BAR;
 
+        registerSeriesNames(this.seriesNameById, series);
         const xy = this.buildXYData(series, this.mode);
-        flushSync(() => this.setState({ xyData: xy, outputStatus: model.status ?? ResponseStatus.COMPLETED }));
+        flushSync(() =>
+            this.setState({
+                xyData: xy,
+                outputStatus: model.status ?? ResponseStatus.COMPLETED,
+                legendColors: buildLegendColors(this.state.xyTree, this.colors, this.seriesNameById)
+            })
+        );
         this.calculateYRange();
 
         // Extract model types from all series

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/entry-tree.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/entry-tree.tsx
@@ -29,6 +29,7 @@ interface EntryTreeProps {
     onOrderReset: () => void;
     showHeader: boolean;
     headers: ColumnHeader[];
+    legendColors?: Record<number, string>;
     className: string;
     hideFillers?: boolean;
 }
@@ -59,7 +60,9 @@ export class EntryTree extends React.Component<EntryTreeProps> {
         this.props.multiSelectedRows !== nextProps.multiSelectedRows ||
         this.props.pinnedRows !== nextProps.pinnedRows ||
         this.props.hideEmptyNodes !== nextProps.hideEmptyNodes ||
-        this.props.emptyNodes !== nextProps.emptyNodes;
+        this.props.emptyNodes !== nextProps.emptyNodes ||
+        this.props.headers !== nextProps.headers ||
+        this.props.legendColors !== nextProps.legendColors;
 
     render(): JSX.Element {
         return <FilterTree nodes={listToTree(this.props.entries, this.props.headers)} {...this.props} />;

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table-body.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table-body.tsx
@@ -20,6 +20,8 @@ interface TableBodyProps {
     onPin?: (id: number) => void;
     onContextMenu: (event: React.MouseEvent<HTMLDivElement>, id: number) => void;
     hideFillers?: boolean;
+    legendColumnIndex?: number;
+    legendColors?: Record<number, string>;
 }
 
 export class TableBody extends React.Component<TableBodyProps> {

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table-cell.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table-cell.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import { TreeNode } from './tree-node';
+import { createLegendSwatch } from './utils';
 
 interface TableCellProps {
     node: TreeNode;
     index: number;
+    legendColumnIndex?: number;
+    legendColors?: Record<number, string>;
     children?: React.ReactNode | React.ReactNode[];
     pinButton?: React.ReactNode;
 }
@@ -16,7 +19,10 @@ export class TableCell extends React.Component<TableCellProps> {
         const { node, index } = this.props;
 
         let content;
-        if (node.elementIndex && node.elementIndex === index && node.getElement) {
+        const legendColor = this.props.legendColumnIndex === index ? this.props.legendColors?.[node.id] : undefined;
+        if (legendColor) {
+            content = createLegendSwatch(legendColor);
+        } else if (node.elementIndex && node.elementIndex === index && node.getElement) {
             content = node.getElement();
         } else {
             content = node.getEnrichedContent ? node.getEnrichedContent() : node.labels[index];

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table-row.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table-row.tsx
@@ -7,6 +7,8 @@ import icons from './icons';
 interface TableRowProps {
     node: TreeNode;
     level: number;
+    legendColumnIndex?: number;
+    legendColors?: Record<number, string>;
     selectedRow?: number;
     multiSelectedRows?: number[];
     collapsedNodes: number[];
@@ -112,14 +114,25 @@ export class TableRow extends React.Component<TableRowProps> {
         );
     };
 
+    private getControlColumnIndex(): number {
+        return 0;
+    }
+
     renderRow = (): React.ReactNode => {
         const { node } = this.props;
+        const controlColumnIndex = this.getControlColumnIndex();
         const row = node.labels.map((_label: string, index) => (
-            <TableCell key={node.id + '-' + index} index={index} node={node}>
-                {index === 0 ? this.renderToggleCollapse() : undefined}
-                {index === 0 ? this.renderCheckbox() : undefined}
-                {index === 0 ? this.renderCloseButton() : undefined}
-                {index === 0 ? this.renderPinButton() : undefined}
+            <TableCell
+                key={node.id + '-' + index}
+                index={index}
+                node={node}
+                legendColumnIndex={this.props.legendColumnIndex}
+                legendColors={this.props.legendColors}
+            >
+                {index === controlColumnIndex ? this.renderToggleCollapse() : undefined}
+                {index === controlColumnIndex ? this.renderCheckbox() : undefined}
+                {index === controlColumnIndex ? this.renderCloseButton() : undefined}
+                {index === controlColumnIndex ? this.renderPinButton() : undefined}
             </TableCell>
         ));
         if (!this.props.hideFillers) {

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/table.tsx
@@ -4,7 +4,7 @@ import { TableHeader } from './table-header';
 import { TableBody } from './table-body';
 import { SortConfig, sortState, nextSortState, sortNodes } from './sort';
 import ColumnHeader from './column-header';
-import { filterEmptyNodes } from './utils';
+import { filterEmptyNodes, getLegendColumnIndex } from './utils';
 
 interface TableProps {
     nodes: TreeNode[];
@@ -33,6 +33,8 @@ interface TableProps {
     hideFillers?: boolean;
     emptyNodes: number[];
     hideEmptyNodes: boolean;
+    legendColumnIndex?: number;
+    legendColors?: Record<number, string>;
 }
 
 export class Table extends React.Component<TableProps> {
@@ -94,6 +96,8 @@ export class Table extends React.Component<TableProps> {
             nodes = filterEmptyNodes(nodes, this.props.emptyNodes, this.props.collapsedNodes);
         }
 
+        const legendColumnIndex = getLegendColumnIndex(this.props.headers);
+
         return (
             <div>
                 <table style={{ gridTemplateColumns: gridTemplateColumns }} className={this.props.className}>
@@ -106,7 +110,7 @@ export class Table extends React.Component<TableProps> {
                             hideFillers={this.props.hideFillers}
                         />
                     )}
-                    <TableBody {...this.props} nodes={nodes} />
+                    <TableBody {...this.props} nodes={nodes} legendColumnIndex={legendColumnIndex} />
                 </table>
             </div>
         );

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/tree.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/tree.tsx
@@ -34,6 +34,7 @@ interface FilterTreeProps {
     headers: ColumnHeader[];
     className: string;
     hideFillers?: boolean;
+    legendColors?: Record<number, string>;
 }
 
 interface FilterTreeState {
@@ -309,6 +310,7 @@ export class FilterTree extends React.Component<FilterTreeProps, FilterTreeState
             headers={this.props.headers}
             className={this.props.className}
             hideFillers={this.props.hideFillers}
+            legendColors={this.props.legendColors}
         />
     );
 

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/utils.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/filter-tree/utils.tsx
@@ -1,22 +1,52 @@
+import * as React from 'react';
 import { Entry } from 'tsp-typescript-client/lib/models/entry';
 import { TreeNode } from './tree-node';
 import ColumnHeader from './column-header';
 
-const entryToTreeNode = (entry: Entry, headers: ColumnHeader[]) => {
-    // TODO Instead of padding the labels, ColumnHeader should use a getter function  instead of just assuming strings, this will allow to get the legend for XY charts
-    const labels = entry.labels && entry.labels.length > 0 ? entry.labels : [''];
-    // Pad the labels to match the header count
-    for (let i = labels.length; i <= headers.length - 1; i++) {
-        labels[i] = '';
+export const LEGEND_COLUMN_TITLE = 'Legend';
+
+export const createLegendSwatch = (color: string): JSX.Element => (
+    <span className="xy-legend-swatch" style={{ backgroundColor: color }} aria-hidden="true" />
+);
+
+export const getLegendColumnIndex = (headers: ColumnHeader[]): number =>
+    headers.findIndex(header => header.title === LEGEND_COLUMN_TITLE);
+
+const buildLabelsForHeaders = (entry: Entry, headers: ColumnHeader[]): string[] => {
+    const legendIndex = getLegendColumnIndex(headers);
+    const labels = entry.labels?.length ? [...entry.labels] : [''];
+
+    if (legendIndex >= 0) {
+        const expectedWithoutLegendLength = headers.length - 1;
+        if (labels.length === expectedWithoutLegendLength) {
+            // Legend column was inserted in headers, so shift labels to keep column alignment.
+            labels.splice(legendIndex, 0, '');
+        } else {
+            // Legend slot already exists (or data shape is unexpected): keep layout stable by blanking it.
+            while (labels.length < headers.length) {
+                labels.push('');
+            }
+            labels[legendIndex] = '';
+        }
     }
-    return {
-        labels: labels,
-        isRoot: false,
-        id: entry.id,
-        parentId: entry.parentId,
-        children: []
-    } as TreeNode;
+
+    while (labels.length < headers.length) {
+        labels.push('');
+    }
+    if (labels.length > headers.length) {
+        labels.length = headers.length;
+    }
+
+    return labels;
 };
+
+const entryToTreeNode = (entry: Entry, headers: ColumnHeader[]): TreeNode => ({
+    labels: buildLabelsForHeaders(entry, headers),
+    isRoot: false,
+    id: entry.id,
+    parentId: entry.parentId ?? -1,
+    children: []
+});
 
 export const listToTree = (list: Entry[], headers: ColumnHeader[]): TreeNode[] => {
     const rootNodes: TreeNode[] = [];

--- a/local-libs/traceviewer-libs/react-components/src/components/utils/xy-shared.ts
+++ b/local-libs/traceviewer-libs/react-components/src/components/utils/xy-shared.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Entry } from 'tsp-typescript-client';
-import { XyEntry } from 'tsp-typescript-client/lib/models/xy';
+import { XYSeries, XyEntry } from 'tsp-typescript-client/lib/models/xy';
 import { TimeRange } from 'traceviewer-base/lib/utils/time-range';
 import { BIMath } from 'timeline-chart/lib/bigint-utils';
-import { listToTree, getCollapsedNodesFromAutoExpandLevel } from './filter-tree/utils';
+import { listToTree, getCollapsedNodesFromAutoExpandLevel, LEGEND_COLUMN_TITLE } from './filter-tree/utils';
 import { axisLeft } from 'd3-axis';
 import { scaleLinear } from 'd3-scale';
 import { select } from 'd3-selection';
@@ -18,11 +18,59 @@ export interface HeaderSpec {
     tooltip?: string;
 }
 
+export { LEGEND_COLUMN_TITLE } from './filter-tree/utils';
+
 export interface ColumnSpec {
     title: string;
     sortable?: boolean;
     resizable?: boolean;
     tooltip?: string;
+}
+
+export function withLegendColumn(columns: ColumnSpec[]): ColumnSpec[] {
+    if (columns.some(column => column.title === LEGEND_COLUMN_TITLE)) {
+        return columns;
+    }
+
+    const legendColumn: ColumnSpec = { title: LEGEND_COLUMN_TITLE, sortable: false, resizable: false };
+
+    const emptyColumnIndex = columns.findIndex((column, index) => index > 0 && !column.title?.trim());
+    if (emptyColumnIndex >= 0) {
+        const result = [...columns];
+        result[emptyColumnIndex] = legendColumn;
+        return result;
+    }
+
+    if (columns.length === 0) {
+        return [{ title: 'Name', sortable: true }, legendColumn];
+    }
+
+    const result = [...columns];
+    result.splice(1, 0, legendColumn);
+    return result;
+}
+
+export function buildLegendColors(
+    entries: Entry[],
+    colors: ColorAllocator,
+    seriesNameById: ReadonlyMap<number, string>
+): Record<number, string> {
+    const legendColors: Record<number, string> = {};
+    entries.forEach(entry => {
+        const key = seriesNameById.get(entry.id);
+        if (key === undefined) {
+            return;
+        }
+        legendColors[entry.id] = colors.get(key);
+    });
+    return legendColors;
+}
+
+export function registerSeriesNames(seriesNameById: Map<number, string>, series: XYSeries[]): void {
+    seriesNameById.clear();
+    series.forEach(item => {
+        seriesNameById.set(item.seriesId, item.seriesName);
+    });
 }
 
 export interface TreeState {
@@ -59,7 +107,7 @@ export function buildTreeStateFromModel(model: {
     autoExpandLevel?: number;
     status?: any;
 }): TreeState {
-    const columns = buildColumns(model.headers);
+    const columns = withLegendColumn(buildColumns(model.headers));
     const checkedSeries = model.entries.filter(e => (e as any).isDefault).map(e => e.id);
     const collapsedNodes = computeAutoCollapsedNodes(model.entries, columns, model.autoExpandLevel);
     const defaultOrderedIds = model.entries.map(e => e.id);

--- a/local-libs/traceviewer-libs/react-components/src/components/xy-output-component.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/xy-output-component.tsx
@@ -39,6 +39,7 @@ export class XYOutputComponent extends AbstractXYOutputComponent<AbstractOutputP
                 : [],
             xyData: {},
             columns: [{ title: 'Name', sortable: true }],
+            legendColors: {},
             allMax: 0,
             allMin: 0,
             cursor: 'default',

--- a/local-libs/traceviewer-libs/react-components/src/components/xy-output-overview-component.tsx
+++ b/local-libs/traceviewer-libs/react-components/src/components/xy-output-overview-component.tsx
@@ -53,6 +53,7 @@ export class XYOutputOverviewComponent extends AbstractXYOutputComponent<XYOutpu
             collapsedNodes: [],
             xyData: {},
             columns: [{ title: 'Name', sortable: true }],
+            legendColors: {},
             allMax: 0,
             allMin: 0,
             cursor: 'default',

--- a/local-libs/traceviewer-libs/react-components/style/output-components-style.css
+++ b/local-libs/traceviewer-libs/react-components/style/output-components-style.css
@@ -237,6 +237,15 @@ canvas {
     text-align: left;
 }
 
+.xy-legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 1px solid var(--trace-viewer-tree-inactiveIndentGuidesStroke);
+    border-radius: 2px;
+    vertical-align: middle;
+}
+
 .table-tree th span {
     overflow: hidden;
     white-space: nowrap;


### PR DESCRIPTION
## Summary

This pull request adds a legends column to the XY trace viewer to improve readability and make it easier to identify plotted series.

## Changes

- Add a legends column to the filter tree.
- Update XY output components to support the new column.
- Adjust table layout and styles.
- Refactor related utility code where necessary.

## Testing

- Verified the legends column is displayed correctly.
- Verified existing XY trace viewer functionality continues to work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-series legend color swatches to XY charts and the filter tree/table.
  * Introduced a dedicated **“Legend”** column to keep legend labeling consistent across views.
* **Bug Fixes**
  * Legend colors now initialize and refresh correctly whenever XY data is rebuilt and when tree/table content updates.
  * Updated rendering so legend/color changes trigger the correct re-renders.
* **Style**
  * Added styling for compact legend swatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->